### PR TITLE
Implement Preconditions (MIDI only so far)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ What's implemented so far:
   - Event matchers (describes an event to matched to trigger an event)
     - Midi Event matcher with flexible parameter value matching options
   - Macros (combining scopes, event matchers, and actions into one package)
+  - Preconditions (state that must be satisfied in addition to an event matching in
+    order to execute a macro)
+    - Midi preconditions for note_on, control, program, pitch_bend
 - Configuration: YAML parser to intermediary "RawConfig" format, plus a parser
   from RawConfig into the aforementioned data structures
 - Command line interfaces covering
@@ -36,7 +39,6 @@ including some future plans.
 
 ## To do:
 
-- Implement the state keeping component (MIDI etc) and precondition data structures
 - Add some action enum types that allow control of the program (like exiting it, reloading config)
 - Investigate portability to non-linux platforms
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -193,9 +193,7 @@ key:
 ```
 will match keys 12, 14, and all the keys from 32 to 44 inclusive.
 
-### Preconditions (NOT IMPLEMENTED YET)
-
-**NOTE: Preconditions are not yet implemented.**
+### Preconditions
 
 A precondition is something that must be satisfied before a macro is allowed to run. These are based on state data
 the program keeps track of.
@@ -217,7 +215,7 @@ expansion to other types later.
   be considered not a match, and vice versa. Optional field, defaulting to `false`.
 - `data`: An object with fields relevant to the precondition type. These specify the condition that must be met.
 
-#### MIDI Preconditions (NOT IMPLEMENTED YET)
+#### MIDI Preconditions 
 
 The program keeps track of notes that are currently on, as well as any control change and program change values.
 

--- a/mmpd-bin/src/tasks/task_main.rs
+++ b/mmpd-bin/src/tasks/task_main.rs
@@ -39,7 +39,7 @@ pub fn task_main(cli_matches: Option<&ArgMatches>) {
     }
 
     let action_runner = action_runner.unwrap();
-    let state = state::new(focus_adapter);
+    let mut state = state::new(focus_adapter);
 
     let (tx, rx) = get_event_bus();
     let handle = midi_adapter.start_listening(&midi_device_name, tx);
@@ -69,6 +69,8 @@ pub fn task_main(cli_matches: Option<&ArgMatches>) {
     }
 
     for event in rx {
+        state.process_event(&event);
+
         for macro_item in config.macros.iter() {
             if let Some(actions) = macro_item.evaluate(&event, &state) {
                 if let Some(macro_name) = macro_item.name() {

--- a/mmpd-lib/src/config/versions/version1/event_matchers.rs
+++ b/mmpd-lib/src/config/versions/version1/event_matchers.rs
@@ -7,7 +7,7 @@ use crate::macros::preconditions::Precondition;
 use crate::config::versions::version1::precondition::build_precondition;
 use midi::build_midi_event_matcher;
 
-/// Constructs an `EventMatcher` instance (in a `Box`) from a Raw `raw_event_matcher`
+/// Constructs an `EventMatcher` instance from a Raw `raw_event_matcher`
 /// `RCHash`'s fields.
 ///
 /// Event matchers are expected to follow this structure:
@@ -25,7 +25,7 @@ use midi::build_midi_event_matcher;
 /// `type` is required. Its value must be one of the implemented event types. Currently, these are:
 ///     - midi
 ///
-/// `data` is not meant to be a hash, but is not strictly required. Depending on the event type, it
+/// `data` is meant to be a hash, but is not strictly required. Depending on the event type, it
 /// may be required, but this function does not enforce it.
 ///
 /// `required_preconditions` is optional. If specified, must be a list of "preconditions". The
@@ -37,7 +37,7 @@ use midi::build_midi_event_matcher;
 /// ## Errors
 /// This function will return `ConfigError` under any of these conditions:
 ///
-/// - `type` field is missing or is not a `RawCondition::String`
+/// - `type` field is missing or is not a `RawConfig::String`
 /// - The value for the `type` field does not match any known event matcher types; see above
 /// - Down the stream, a more specific event matcher (such as `MidiEventMatcher`) fails to be
 ///   constructed for any reason

--- a/mmpd-lib/src/config/versions/version1/event_matchers.rs
+++ b/mmpd-lib/src/config/versions/version1/event_matchers.rs
@@ -182,9 +182,9 @@ mod tests {
                 }),
 
                 required_preconditions: Some(vec![
-                    Precondition {},
-                    Precondition {},
-                    Precondition {}
+                    Precondition::Other,
+                    Precondition::Other,
+                    Precondition::Other
                 ])
             }
         );

--- a/mmpd-lib/src/config/versions/version1/event_matchers.rs
+++ b/mmpd-lib/src/config/versions/version1/event_matchers.rs
@@ -91,7 +91,7 @@ mod tests {
     use crate::config::versions::version1::event_matchers::build_event_matcher;
     use crate::macros::event_matching::{EventMatcher, MatcherType};
     use crate::macros::event_matching::midi::MidiEventMatcher;
-    use crate::macros::preconditions::Precondition;
+    use crate::macros::preconditions::{Precondition, PreconditionType};
 
     #[test]
     fn returns_error_if_missing_type_field() {
@@ -182,9 +182,9 @@ mod tests {
                 }),
 
                 required_preconditions: Some(vec![
-                    Precondition::Other,
-                    Precondition::Other,
-                    Precondition::Other
+                    Precondition { invert: false, condition: PreconditionType::Other },
+                    Precondition { invert: false, condition: PreconditionType::Other },
+                    Precondition { invert: false, condition: PreconditionType::Other },
                 ])
             }
         );

--- a/mmpd-lib/src/config/versions/version1/event_matchers/midi.rs
+++ b/mmpd-lib/src/config/versions/version1/event_matchers/midi.rs
@@ -3,8 +3,7 @@ use crate::config::ConfigError;
 use crate::config::versions::version1::primitive_matchers::build_number_matcher;
 use crate::macros::event_matching::midi::MidiEventMatcher;
 
-/// Constructs a `MidiEventMatcher` (returned as a `Box<dyn MatchChecker<MidiMessage>>`) from a
-/// `data` `RCHash`.
+/// Constructs a `MidiEventMatcher` from a `data` `RCHash`.
 ///
 /// `data` should be structured as follows:
 /// ```yaml

--- a/mmpd-lib/src/config/versions/version1/precondition.rs
+++ b/mmpd-lib/src/config/versions/version1/precondition.rs
@@ -1,17 +1,126 @@
-use crate::config::raw_config::RCHash;
+mod midi;
+
+use crate::config::raw_config::{RCHash, AccessHelpers};
 use crate::macros::preconditions::{Precondition, PreconditionType};
 use crate::config::ConfigError;
+use crate::config::versions::version1::precondition::midi::build_midi_precondition;
 
-/// Constructs a `Precondition` from a `_raw_precondition` `RCHash`.
+/// Constructs a `Precondition` instance from a raw `raw_precondition` `RCHash`'s fields.
 ///
-/// Since preconditions aren't implemented yet (beyond a stub), this always returns a blank
-/// `Precondition` instance regardless of the contents of `_raw_precondition`.
-pub (crate) fn build_precondition(_raw_precondition: &RCHash) -> Result<Precondition, ConfigError> {
-    Ok(Precondition { invert: false, condition: PreconditionType::Other })
+/// Preconditions are expected to follow this structure:
+///
+/// ```yaml
+/// type: "precondition type goes here"
+/// invert: true|false
+/// data:
+///     # (Any fields relevant to the precondition type)
+/// ```
+///
+/// `type` is required. Its value must be one of the implemented precondition types. Currently,
+/// there are:
+///     - midi
+///
+/// `invert` is optional, and specifies whether the condition should be inverted; it essentially
+/// applies a logic "NOT" to the question "does this precondition match?" Defaults to `false`.
+///
+/// `data` is meant to be a hash, but is not strictly required. Depending on the event type it may
+/// be required, but this function does not enforce it.
+///
+/// ## Errors
+/// This function will return `ConfigError` under any of these conditions:
+///
+/// - `type` field is missing or is not a `RawConfig::String`
+/// - The value for the `type` field does not match any known precondition types; see above
+/// - Down the stream, a precondition type such as `MidiPrecondition`  fails to be constructed for
+///   any reason
+pub (crate) fn build_precondition(raw_precondition: &RCHash) -> Result<Precondition, ConfigError> {
+    const TYPE_FIELD: &str = "type";
+    const INVERT_FIELD: &str = "invert";
+    const DATA_FIELD: &str = "data";
+
+    const TYPE_MIDI: &str = "midi";
+
+    let condition_type = raw_precondition.get_string(TYPE_FIELD).ok_or_else(|| {
+        ConfigError::InvalidConfig(
+            format!("precondition missing valid (string) '{}' field", TYPE_FIELD)
+        )
+    })?;
+
+    let invert = raw_precondition.get_bool(INVERT_FIELD).unwrap_or(false);
+
+    let data = raw_precondition.get_hash(DATA_FIELD);
+
+    Ok(Precondition {
+        invert,
+        condition: match condition_type {
+            TYPE_MIDI => PreconditionType::Midi(build_midi_precondition(data)?),
+
+            _ => {
+                return Err(ConfigError::InvalidConfig(
+                    format!("Unknown precondition type '{}'", condition_type)
+                ));
+            }
+        }
+    })
 }
 
 #[cfg(test)]
 mod tests {
-    // TODO once preconditions are implemented
-}
+    use crate::config::raw_config::{RCHash, k};
+    use crate::config::raw_config::RawConfig;
+    use crate::config::versions::version1::precondition::build_precondition;
+    use crate::macros::preconditions::{Precondition, PreconditionType};
+    use crate::macros::preconditions::midi::MidiPrecondition;
 
+    #[test]
+    fn builds_a_valid_precondition() {
+        let mut hash = RCHash::new();
+        hash.insert(k("type"), k("midi"));
+        hash.insert(k("invert"), RawConfig::Bool(true));
+
+        let mut midi_hash = RCHash::new();
+        midi_hash.insert(k("condition_type"), k("program"));
+
+        hash.insert(k("data"), RawConfig::Hash(midi_hash));
+
+        let condition = build_precondition(&hash)
+            .ok().unwrap();
+
+        assert_eq!(
+            condition,
+            Precondition {
+                invert: true,
+                condition: PreconditionType::Midi(
+                    MidiPrecondition::Program {
+                        channel_match: None,
+                        program_match: None
+                    }
+                )
+            }
+        );
+    }
+
+    #[test]
+    fn returns_an_error_if_type_field_is_missing() {
+        let hash = RCHash::new();
+        let condition = build_precondition(&hash);
+        assert!(condition.is_err());
+    }
+
+    #[test]
+    fn returns_an_error_if_type_field_has_invalid_value() {
+        let mut hash = RCHash::new();
+        hash.insert(k("type"), k("InvalidType"));
+        let condition = build_precondition(&hash);
+        assert!(condition.is_err());
+    }
+
+    #[test]
+    fn returns_an_error_if_downstream_build_errors() {
+        let mut hash = RCHash::new();
+        hash.insert(k("type"), k("midi"));
+        hash.insert(k("data"), RawConfig::Null);
+        let condition = build_precondition(&hash);
+        assert!(condition.is_err());
+    }
+}

--- a/mmpd-lib/src/config/versions/version1/precondition.rs
+++ b/mmpd-lib/src/config/versions/version1/precondition.rs
@@ -7,7 +7,7 @@ use crate::config::ConfigError;
 /// Since preconditions aren't implemented yet (beyond a stub), this always returns a blank
 /// `Precondition` instance regardless of the contents of `_raw_precondition`.
 pub (crate) fn build_precondition(_raw_precondition: &RCHash) -> Result<Precondition, ConfigError> {
-    Ok(Precondition::new())
+    Ok(Precondition::Other)
 }
 
 #[cfg(test)]

--- a/mmpd-lib/src/config/versions/version1/precondition.rs
+++ b/mmpd-lib/src/config/versions/version1/precondition.rs
@@ -1,5 +1,5 @@
 use crate::config::raw_config::RCHash;
-use crate::macros::preconditions::Precondition;
+use crate::macros::preconditions::{Precondition, PreconditionType};
 use crate::config::ConfigError;
 
 /// Constructs a `Precondition` from a `_raw_precondition` `RCHash`.
@@ -7,7 +7,7 @@ use crate::config::ConfigError;
 /// Since preconditions aren't implemented yet (beyond a stub), this always returns a blank
 /// `Precondition` instance regardless of the contents of `_raw_precondition`.
 pub (crate) fn build_precondition(_raw_precondition: &RCHash) -> Result<Precondition, ConfigError> {
-    Ok(Precondition::Other)
+    Ok(Precondition { invert: false, condition: PreconditionType::Other })
 }
 
 #[cfg(test)]

--- a/mmpd-lib/src/config/versions/version1/precondition/midi.rs
+++ b/mmpd-lib/src/config/versions/version1/precondition/midi.rs
@@ -1,0 +1,336 @@
+use crate::macros::preconditions::midi::MidiPrecondition;
+use crate::config::raw_config::{RCHash, AccessHelpers, k};
+use crate::config::ConfigError;
+use crate::config::versions::version1::primitive_matchers::build_number_matcher;
+
+/// Constructs a `MidiPrecondition` from a `data` `RCHash`.
+///
+/// `data` should be structured as follows:
+/// ```yaml
+/// condition_type: note_on
+/// channel: (number matcher)
+/// key: (number matcher)
+/// ```
+///
+/// This is just one example; there are different valid properties, depending on the value of
+/// `condition_type`. All the expected values for the the non-`condition_type` fields are number
+/// matchers. see `build_number_matcher` for details of what a number matcher entails.
+///
+/// Here's an exhaustive list of additional available condition_types and the fields available for
+/// them.
+///
+/// - `note_on` - A key is currently held
+///     - `channel` - Which MIDI channel the key is pressed for (0-15)
+///     - `key` - Which key is pressed (0-127)
+/// - `control` - A control value is known and matches some value, from "control_change" messages
+///     - `channel` - Which MIDI channel the control is on (0-15)
+///     - `control` - Control identifier (0-127)
+///     - `value` - Known value the control is set to (0-127)
+/// - `program` - A program setting, from "program_change" messages
+///     - `channel` - Which MIDI channel the program setting is for (0-15)
+///     - `program` - The currently set program number (0-127)
+/// - `pitch_bend` - Position of the pitch bender, from "pitch_bend_change" messages
+///     - `channel` - Which MIDI channel the pitch bend setting is on (0-15)
+///     - `value` - What the last known pitch bend value is (0-16383)
+///
+/// ## Errors
+/// The function returns `ConfigError` in any of the following conditions:
+///
+/// - No `data` is specified
+/// - No `condition_type` string field is found in `data`
+/// - `condition_type` is not one of the support values (see above)
+/// - Downstream, there is an issue constructing a number matcher for any reason
+pub fn build_midi_precondition(
+    data: Option<&RCHash>
+) -> Result<MidiPrecondition, ConfigError> {
+    const CONDITION_TYPE_FIELD: &str = "condition_type";
+
+    const NOTE_ON_CONDITION: &str = "note_on";
+    const CONTROL_CONDITION: &str = "control";
+    const PROGRAM_CONDITION: &str = "program";
+    const PITCH_BEND_CONDITION: &str = "pitch_bend";
+
+    const CHANNEL_FIELD: &str = "channel";
+    const KEY_FIELD: &str = "key";
+    const CONTROL_FIELD: &str = "control";
+    const VALUE_FIELD: &str = "value";
+    const PROGRAM_FIELD: &str = "program";
+
+    let data = data.ok_or_else(|| {
+        ConfigError::InvalidConfig("Missing data for midi precondition".to_string())
+    })?;
+
+    let condition_type = data.get_string(CONDITION_TYPE_FIELD).ok_or_else(|| {
+        ConfigError::InvalidConfig(format!(
+            "Missing {} field in midi precondition data",
+            CONDITION_TYPE_FIELD
+        ))
+    })?;
+
+    let raw_channel_matcher = data.get(&k(CHANNEL_FIELD));
+    let channel_match = build_number_matcher(raw_channel_matcher)?;
+
+    Ok(match condition_type {
+        NOTE_ON_CONDITION => MidiPrecondition::NoteOn {
+            channel_match,
+            key_match: build_number_matcher(data.get(&k(KEY_FIELD)))?
+        },
+
+        CONTROL_CONDITION => MidiPrecondition::Control {
+            channel_match,
+            control_match: build_number_matcher(data.get(&k(CONTROL_FIELD)))?,
+            value_match: build_number_matcher(data.get(&k(VALUE_FIELD)))?
+        },
+
+        PROGRAM_CONDITION => MidiPrecondition::Program {
+            channel_match,
+            program_match: build_number_matcher(data.get(&k(PROGRAM_FIELD)))?
+        },
+
+        PITCH_BEND_CONDITION => MidiPrecondition::PitchBend {
+            channel_match,
+            value_match: build_number_matcher(data.get(&k(VALUE_FIELD)))?
+        },
+
+        _ => {
+            return Err(ConfigError::InvalidConfig(
+               format!(
+                   "Invalid or unsupported MIDI condition_type '{}'",
+                   condition_type
+               )
+            ));
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::raw_config::{RCHash, k, RawConfig};
+    use crate::config::versions::version1::precondition::midi::build_midi_precondition;
+    use crate::macros::preconditions::midi::MidiPrecondition;
+    use crate::match_checker::NumberMatcher;
+
+    #[test]
+    fn builds_note_on_precondition() {
+        let mut hash = RCHash::new();
+        hash.insert(k("condition_type"), k("note_on"));
+        hash.insert(k("channel"), RawConfig::Integer(2));
+        hash.insert(k("key"), RawConfig::Integer(42));
+
+        let condition = build_midi_precondition(Some(&hash))
+            .ok().unwrap();
+
+        assert_eq!(
+            condition,
+            MidiPrecondition::NoteOn {
+                channel_match: Some(NumberMatcher::Val(2)),
+                key_match: Some(NumberMatcher::Val(42))
+            }
+        );
+
+        // Sparse version
+        let mut hash = RCHash::new();
+        hash.insert(k("condition_type"), k("note_on"));
+
+        let condition = build_midi_precondition(Some(&hash))
+            .ok().unwrap();
+
+        assert_eq!(
+            condition,
+            MidiPrecondition::NoteOn {
+                channel_match: None,
+                key_match: None
+            }
+        );
+    }
+
+    #[test]
+    fn builds_control_precondition() {
+        let mut hash = RCHash::new();
+        hash.insert(k("condition_type"), k("control"));
+        hash.insert(k("channel"), RawConfig::Integer(2));
+        hash.insert(k("control"), RawConfig::Integer(1));
+        hash.insert(k("value"), RawConfig::Integer(75));
+
+        let condition = build_midi_precondition(Some(&hash))
+            .ok().unwrap();
+
+        assert_eq!(
+            condition,
+            MidiPrecondition::Control {
+                channel_match: Some(NumberMatcher::Val(2)),
+                control_match: Some(NumberMatcher::Val(1)),
+                value_match: Some(NumberMatcher::Val(75))
+            }
+        );
+
+        let mut hash = RCHash::new();
+        hash.insert(k("condition_type"), k("control"));
+
+        let condition = build_midi_precondition(Some(&hash))
+            .ok().unwrap();
+
+        assert_eq!(
+            condition,
+            MidiPrecondition::Control {
+                channel_match: None,
+                control_match: None,
+                value_match: None
+            }
+        );
+    }
+
+    #[test]
+    fn builds_program_precondition() {
+        let mut hash = RCHash::new();
+        hash.insert(k("condition_type"), k("program"));
+        hash.insert(k("channel"), RawConfig::Integer(2));
+        hash.insert(k("program"), RawConfig::Integer(42));
+
+        let condition = build_midi_precondition(Some(&hash))
+            .ok().unwrap();
+
+        assert_eq!(
+            condition,
+            MidiPrecondition::Program {
+                channel_match: Some(NumberMatcher::Val(2)),
+                program_match: Some(NumberMatcher::Val(42))
+            }
+        );
+
+        let mut hash = RCHash::new();
+        hash.insert(k("condition_type"), k("program"));
+
+        let condition = build_midi_precondition(Some(&hash))
+            .ok().unwrap();
+
+        assert_eq!(
+            condition,
+            MidiPrecondition::Program {
+                channel_match: None,
+                program_match: None
+            }
+        );
+    }
+
+    #[test]
+    fn builds_pitch_bend_precondition() {
+        let mut hash = RCHash::new();
+        hash.insert(k("condition_type"), k("pitch_bend"));
+        hash.insert(k("channel"), RawConfig::Integer(2));
+        hash.insert(k("value"), RawConfig::Integer(42));
+
+        let condition = build_midi_precondition(Some(&hash))
+            .ok().unwrap();
+
+        assert_eq!(
+            condition,
+            MidiPrecondition::PitchBend {
+                channel_match: Some(NumberMatcher::Val(2)),
+                value_match: Some(NumberMatcher::Val(42))
+            }
+        );
+
+        let mut hash = RCHash::new();
+        hash.insert(k("condition_type"), k("pitch_bend"));
+
+        let condition = build_midi_precondition(Some(&hash))
+            .ok().unwrap();
+
+        assert_eq!(
+            condition,
+            MidiPrecondition::PitchBend {
+                channel_match: None,
+                value_match: None,
+            }
+        );
+    }
+
+    #[test]
+    fn returns_error_if_no_data_provided() {
+        let condition = build_midi_precondition(None);
+        assert!(condition.is_err());
+    }
+
+    #[test]
+    fn returns_error_if_condition_type_field_is_missing() {
+        let hash = RCHash::new();
+        let condition = build_midi_precondition(Some(&hash));
+        assert!(condition.is_err());
+    }
+
+    #[test]
+    fn returns_error_if_condition_type_has_invalid_value() {
+        let mut hash = RCHash::new();
+        hash.insert(k("condition_type"), k("InvalidValueHere"));
+
+        let condition = build_midi_precondition(Some(&hash));
+        assert!(condition.is_err());
+    }
+
+    #[test]
+    fn returns_error_if_invalid_number_matcher_data_provided() {
+        // note_on, bad data for channel
+        let mut hash = RCHash::new();
+        hash.insert(k("condition_type"), k("note_on"));
+        hash.insert(k("channel"), RawConfig::Integer(-1));
+        let condition = build_midi_precondition(Some(&hash));
+        assert!(condition.is_err());
+
+        // note_on, bad data for key
+        let mut hash = RCHash::new();
+        hash.insert(k("condition_type"), k("note_on"));
+        hash.insert(k("key"), RawConfig::Integer(-1));
+        let condition = build_midi_precondition(Some(&hash));
+        assert!(condition.is_err());
+
+        // control, bad data for channel
+        let mut hash = RCHash::new();
+        hash.insert(k("condition_type"), k("control"));
+        hash.insert(k("channel"), RawConfig::Integer(-1));
+        let condition = build_midi_precondition(Some(&hash));
+        assert!(condition.is_err());
+
+        // control, bad data for control
+        let mut hash = RCHash::new();
+        hash.insert(k("condition_type"), k("control"));
+        hash.insert(k("control"), RawConfig::Integer(-1));
+        let condition = build_midi_precondition(Some(&hash));
+        assert!(condition.is_err());
+
+        // control, bad data for value
+        let mut hash = RCHash::new();
+        hash.insert(k("condition_type"), k("control"));
+        hash.insert(k("value"), RawConfig::Integer(-1));
+        let condition = build_midi_precondition(Some(&hash));
+        assert!(condition.is_err());
+
+        // program, bad data for channel
+        let mut hash = RCHash::new();
+        hash.insert(k("condition_type"), k("program"));
+        hash.insert(k("channel"), RawConfig::Integer(-1));
+        let condition = build_midi_precondition(Some(&hash));
+        assert!(condition.is_err());
+
+        // program, bad data for program
+        let mut hash = RCHash::new();
+        hash.insert(k("condition_type"), k("program"));
+        hash.insert(k("program"), RawConfig::Integer(-1));
+        let condition = build_midi_precondition(Some(&hash));
+        assert!(condition.is_err());
+
+        // pitch_bend, bad data for channel
+        let mut hash = RCHash::new();
+        hash.insert(k("condition_type"), k("pitch_bend"));
+        hash.insert(k("channel"), RawConfig::Integer(-1));
+        let condition = build_midi_precondition(Some(&hash));
+        assert!(condition.is_err());
+
+        // pitch_bend bad data for value
+        let mut hash = RCHash::new();
+        hash.insert(k("condition_type"), k("pitch_bend"));
+        hash.insert(k("value"), RawConfig::Integer(-1));
+        let condition = build_midi_precondition(Some(&hash));
+        assert!(condition.is_err());
+    }
+}

--- a/mmpd-lib/src/config/versions/version1/precondition/midi.rs
+++ b/mmpd-lib/src/config/versions/version1/precondition/midi.rs
@@ -164,6 +164,7 @@ mod tests {
             }
         );
 
+        // Sparse version
         let mut hash = RCHash::new();
         hash.insert(k("condition_type"), k("control"));
 
@@ -198,6 +199,7 @@ mod tests {
             }
         );
 
+        // Sparse version
         let mut hash = RCHash::new();
         hash.insert(k("condition_type"), k("program"));
 
@@ -231,6 +233,7 @@ mod tests {
             }
         );
 
+        // Sparse version
         let mut hash = RCHash::new();
         hash.insert(k("condition_type"), k("pitch_bend"));
 

--- a/mmpd-lib/src/macros.rs
+++ b/mmpd-lib/src/macros.rs
@@ -148,7 +148,7 @@ impl Macro {
         }
 
         if let Some(conditions) = &self.required_preconditions {
-            if conditions.iter().any(|condition| !state.matches(condition)) {
+            if conditions.iter().any(|condition| !state.matches_precondition(condition)) {
                 return None;
             }
         }

--- a/mmpd-lib/src/macros/event_matching.rs
+++ b/mmpd-lib/src/macros/event_matching.rs
@@ -30,7 +30,7 @@ impl EventMatcher {
         // If any one precondition is not satisfies, no further precondition is evaluated,
         // nor is the event object matched against MatcherType.
         if let Some(conditions) = &self.required_preconditions {
-            if conditions.iter().any(|condition| !state.matches(condition)) {
+            if conditions.iter().any(|condition| !state.matches_precondition(condition)) {
                 return false;
             }
         }

--- a/mmpd-lib/src/macros/preconditions.rs
+++ b/mmpd-lib/src/macros/preconditions.rs
@@ -1,10 +1,4 @@
 #[derive(PartialEq, Debug)]
-pub struct Precondition {
-
-}
-
-impl Precondition {
-    pub fn new() -> Precondition {
-        Precondition {}
-    }
+pub enum Precondition {
+    Other
 }

--- a/mmpd-lib/src/macros/preconditions.rs
+++ b/mmpd-lib/src/macros/preconditions.rs
@@ -3,7 +3,14 @@ pub mod midi;
 use midi::MidiPrecondition;
 
 #[derive(PartialEq, Debug)]
-pub enum Precondition {
+pub struct Precondition {
+    pub invert: bool,
+    pub condition: PreconditionType
+}
+
+// TODO: turn back into a struct so it can have an `invert` field
+#[derive(PartialEq, Debug)]
+pub enum PreconditionType {
     Midi(MidiPrecondition),
     Other // Placeholder
 }

--- a/mmpd-lib/src/macros/preconditions.rs
+++ b/mmpd-lib/src/macros/preconditions.rs
@@ -8,7 +8,6 @@ pub struct Precondition {
     pub condition: PreconditionType
 }
 
-// TODO: turn back into a struct so it can have an `invert` field
 #[derive(PartialEq, Debug)]
 pub enum PreconditionType {
     Midi(MidiPrecondition),

--- a/mmpd-lib/src/macros/preconditions.rs
+++ b/mmpd-lib/src/macros/preconditions.rs
@@ -1,4 +1,9 @@
+pub mod midi;
+
+use midi::MidiPrecondition;
+
 #[derive(PartialEq, Debug)]
 pub enum Precondition {
-    Other
+    Midi(MidiPrecondition),
+    Other // Placeholder
 }

--- a/mmpd-lib/src/macros/preconditions/midi.rs
+++ b/mmpd-lib/src/macros/preconditions/midi.rs
@@ -1,0 +1,18 @@
+use crate::match_checker::NumMatch;
+
+/// Precondition to be checked against MidiState
+#[derive(Debug, PartialEq)]
+pub enum MidiPrecondition {
+    /// A note with a channel matching the channel matcher and the key matcher is currently held
+    NoteOn { channel_match: NumMatch, key_match: NumMatch },
+
+    /// A control matching the channel and control matchers matches the value matcher
+    Control { channel_match: NumMatch, control_match: NumMatch, value_match: NumMatch },
+
+    /// A channel matching the channel matcher has its program set to a program matching the
+    /// program matcher
+    Program { channel_match: NumMatch, program_match: NumMatch },
+
+    /// A channel matching the channel matcher has a pitch bend value matching the value matcher
+    PitchBend { channel_match: NumMatch, value_match: NumMatch },
+}

--- a/mmpd-lib/src/state.rs
+++ b/mmpd-lib/src/state.rs
@@ -3,7 +3,7 @@ mod midi_state;
 use crate::macros::Scope;
 use crate::focus::adapters::FocusAdapter;
 use crate::match_checker::MatchChecker;
-use crate::macros::preconditions::Precondition;
+use crate::macros::preconditions::{Precondition, PreconditionType};
 
 #[cfg(test)]
 use mockall::automock;
@@ -86,9 +86,16 @@ impl State for StateImpl {
     }
 
     fn matches_precondition(&self, precondition: &Precondition) -> bool {
-        match precondition {
-            Precondition::Midi(condition) => self.midi.matches(condition),
-            Precondition::Other => true
+        let normal_match = match &precondition.condition {
+            PreconditionType::Midi(condition) => self.midi.matches(condition),
+            PreconditionType::Other => true
+        };
+
+
+        if precondition.invert  {
+            !normal_match
+        } else {
+            normal_match
         }
     }
 }

--- a/mmpd-lib/src/state.rs
+++ b/mmpd-lib/src/state.rs
@@ -1,3 +1,5 @@
+mod midi_state;
+
 use crate::macros::Scope;
 use crate::focus::adapters::FocusAdapter;
 use crate::match_checker::MatchChecker;
@@ -5,9 +7,13 @@ use crate::macros::preconditions::Precondition;
 
 #[cfg(test)]
 use mockall::automock;
+use crate::macros::event_matching::Event;
+use crate::state::midi_state::MidiState;
 
 #[cfg_attr(test, automock)]
 pub trait State {
+    fn process_event(&mut self, event: &Event);
+
     fn matches_scope(&self, scope: &Option<Scope>) -> bool;
 
     fn matches(&self, val: &Precondition) -> bool;
@@ -20,7 +26,8 @@ pub fn new(
 }
 
 struct StateImpl {
-    focus_adapter: Box<dyn FocusAdapter>
+    focus_adapter: Box<dyn FocusAdapter>,
+    midi: MidiState
 }
 
 impl StateImpl {
@@ -28,12 +35,20 @@ impl StateImpl {
         focus_adapter: Box<dyn FocusAdapter>
     ) -> Box<dyn State> {
         Box::new(StateImpl {
-            focus_adapter
+            focus_adapter,
+            midi: MidiState::new()
         })
     }
 }
 
 impl State for StateImpl {
+    fn process_event(&mut self, event: &Event) {
+        match event {
+            Event::Midi(midi_msg) => self.midi.process_message(midi_msg),
+            Event::Other => {}
+        }
+    }
+
     fn matches_scope(&self, scope: &Option<Scope>) -> bool {
         if scope.is_none() {
             return true

--- a/mmpd-lib/src/state.rs
+++ b/mmpd-lib/src/state.rs
@@ -16,7 +16,7 @@ pub trait State {
 
     fn matches_scope(&self, scope: &Option<Scope>) -> bool;
 
-    fn matches(&self, val: &Precondition) -> bool;
+    fn matches_precondition(&self, precondition: &Precondition) -> bool;
 }
 
 pub fn new(
@@ -85,7 +85,10 @@ impl State for StateImpl {
         }
     }
 
-    fn matches(&self, _val: &Precondition) -> bool {
-        true
+    fn matches_precondition(&self, precondition: &Precondition) -> bool {
+        match precondition {
+            Precondition::Midi(condition) => self.midi.matches(condition),
+            Precondition::Other => true
+        }
     }
 }

--- a/mmpd-lib/src/state/midi_state.rs
+++ b/mmpd-lib/src/state/midi_state.rs
@@ -1,0 +1,310 @@
+use crate::midi::MidiMessage;
+use std::collections::{HashSet, HashMap};
+
+/// State tracking container for MIDI messages.
+///
+/// MidiState keeps track off:
+/// - Which notes are currently pressed / "on" for each channel
+/// - All known values of controls per channel
+/// - All known selected programs for each channel
+/// - All known pitch bend values for each channel
+///
+/// It only starts storing values for each of these the moment a MIDI message with relevant
+/// data comes in. If for example, a key was pressed before the program was running, MidiState
+/// would have no record of that key currently being pressed.
+pub(crate) struct MidiState {
+    /// Set of notes that are currently pressed
+    notes_on: HashSet<Note>,
+
+    // Control values for any controls we've received messages about
+    controls: HashMap<Control, u8>,
+
+    // Chosen programs for each channel that we've received program change messages for.
+    // The key number here is the channel.
+    programs: HashMap<u8, u8>,
+
+    // Pitch bend positions for each channel that we've received pitch bend messages for
+    // The key number here is the channel.
+    pitch_bend_values: HashMap<u8, u16>
+}
+
+/// Represents a unique note, scoped by channel and key
+#[derive(Hash, Eq, PartialEq, Debug)]
+struct Note {
+    channel: u8,
+    key: u8,
+}
+
+/// Represents a unique control, scoped by channel and control number
+#[derive(Hash, Eq, PartialEq, Debug)]
+struct Control {
+    channel: u8,
+    control: u8,
+}
+
+impl MidiState {
+    pub fn new() -> MidiState {
+        MidiState {
+            notes_on: HashSet::new(),
+            controls: HashMap::new(),
+            programs: HashMap::new(),
+            pitch_bend_values: HashMap::new()
+        }
+    }
+
+    /// Processes an incoming MIDI message, mutating itself as a result.
+    /// Message types that are relevant to MidiState are:
+    /// - NoteOn
+    /// - NoteOff
+    /// - ControlChange
+    /// - ProgramChange
+    /// - PitchBendChange
+    ///
+    /// Any other messages are ignored.
+    pub fn process_message(&mut self, msg: &MidiMessage) {
+        match msg {
+            MidiMessage::NoteOn { channel, key, .. } => {
+                self.notes_on.insert(
+                    Note { channel: *channel, key: *key }
+                );
+            }
+
+            MidiMessage::NoteOff { channel, key, .. } => {
+                self.notes_on.remove(
+                    &Note { channel: *channel, key: *key }
+                );
+            },
+
+            MidiMessage::ControlChange { channel, control, value } => {
+                self.controls.insert(
+                    Control { channel: *channel, control: *control },
+                    *value
+                );
+            }
+
+            MidiMessage::ProgramChange { channel, program } => {
+                self.programs.insert(*channel, *program);
+            }
+
+            MidiMessage::PitchBendChange { channel, value } => {
+                self.pitch_bend_values.insert(*channel, *value);
+            }
+
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::midi::MidiMessage;
+    use crate::state::midi_state::{MidiState, Note, Control};
+
+    #[test]
+    fn keeps_track_of_notes_held() {
+        let note1 = Note { channel: 3, key: 20 };
+        let note2 = Note { channel: 7, key: 30 };
+
+        let mut state = MidiState::new();
+        assert!(state.notes_on.is_empty());
+
+        // Pressing notes
+
+        let note_on_msg1 = MidiMessage::NoteOn {
+            channel: note1.channel,
+            key: note1.key,
+            velocity: 67
+        };
+
+        let note_on_msg2 = MidiMessage::NoteOn {
+            channel: note2.channel,
+            key: note2.key,
+            velocity: 42
+        };
+
+        state.process_message(&note_on_msg1);
+        assert!(state.notes_on.contains(&note1));
+
+        state.process_message(&note_on_msg2);
+        assert!(state.notes_on.contains(&note1));
+        assert!(state.notes_on.contains(&note2));
+
+        // Releasing notes
+
+        let note_off_msg1 = MidiMessage::NoteOff {
+            channel: note1.channel,
+            key: note1.key,
+            velocity: 64
+        };
+
+        let note_off_msg2 = MidiMessage::NoteOff {
+            channel: note2.channel,
+            key: note2.key,
+            velocity: 120
+        };
+
+        state.process_message(&note_off_msg1);
+        assert!(!state.notes_on.contains(&note1));
+        assert!(state.notes_on.contains(&note2));
+
+        state.process_message(&note_off_msg2);
+        assert!(state.notes_on.is_empty());
+    }
+
+    #[test]
+    fn keeps_only_one_record_of_a_pressed_note() {
+        let note1 = Note { channel: 3, key: 20 };
+
+        let mut state = MidiState::new();
+
+        let note_on_msg1 = MidiMessage::NoteOn {
+            channel: note1.channel,
+            key: note1.key,
+            velocity: 67
+        };
+
+        state.process_message(&note_on_msg1);
+        state.process_message(&note_on_msg1);
+
+        assert!(state.notes_on.contains(&note1));
+
+        let note_off_msg1 = MidiMessage::NoteOff {
+            channel: note1.channel,
+            key: note1.key,
+            velocity: 67
+        };
+
+        state.process_message(&note_off_msg1);
+
+        assert!(!state.notes_on.contains(&note1));
+        assert!(state.notes_on.is_empty());
+    }
+
+    #[test]
+    fn deals_with_note_off_for_note_that_was_not_held() {
+        // We'll press this
+        let note1 = Note { channel: 3, key: 20 };
+
+        // We'll never press this, but release it
+        let note2 = Note { channel: 7, key: 30 };
+
+        let mut state = MidiState::new();
+
+        let note_on_msg1 = MidiMessage::NoteOn {
+            channel: note1.channel,
+            key: note1.key,
+            velocity: 67
+        };
+
+        let note_off_msg2 = MidiMessage::NoteOff {
+            channel: note2.channel,
+            key: note2.key,
+            velocity: 100
+        };
+
+        let note_off_msg1 = MidiMessage::NoteOff {
+            channel: note1.channel,
+            key: note1.key,
+            velocity: 99
+        };
+
+        state.process_message(&note_on_msg1);
+
+        assert!(state.notes_on.contains(&note1));
+        assert!(!state.notes_on.contains(&note2));
+
+        state.process_message(&note_off_msg2);
+
+        assert!(state.notes_on.contains(&note1));
+        assert!(!state.notes_on.contains(&note2));
+
+        state.process_message(&note_off_msg1);
+
+        assert!(!state.notes_on.contains(&note1));
+        assert!(!state.notes_on.contains(&note2));
+        assert!(state.notes_on.is_empty());
+    }
+
+    #[test]
+    fn keeps_track_of_control_changes() {
+        let control1 = Control { channel: 1, control: 3 };
+
+        let mut state = MidiState::new();
+
+        assert!(state.controls.get(&control1).is_none());
+
+        let control_change1 = MidiMessage::ControlChange {
+            channel: control1.channel,
+            control: control1.control,
+            value: 40
+        };
+
+        state.process_message(&control_change1);
+
+        assert_eq!(state.controls.get(&control1), Some(&40));
+
+        let control_change1 = MidiMessage::ControlChange {
+            channel: control1.channel,
+            control: control1.control,
+            value: 50
+        };
+
+        state.process_message(&control_change1);
+
+        assert_eq!(state.controls.get(&control1), Some(&50));
+    }
+
+    #[test]
+    fn keeps_track_of_program_changes() {
+        let channel = 4u8;
+
+        let mut state = MidiState::new();
+
+        assert!(state.programs.get(&channel).is_none());
+
+        let program_change1 = MidiMessage::ProgramChange {
+            channel,
+            program: 2
+        };
+
+        state.process_message(&program_change1);
+
+        assert_eq!(state.programs.get(&channel), Some(&2));
+
+        let program_change1 = MidiMessage::ProgramChange {
+            channel,
+            program: 60
+        };
+
+        state.process_message(&program_change1);
+
+        assert_eq!(state.programs.get(&channel), Some(&60));
+    }
+
+    #[test]
+    fn keeps_track_of_pitch_bend_changes() {
+        let channel = 4u8;
+
+        let mut state = MidiState::new();
+
+        assert!(state.pitch_bend_values.get(&channel).is_none());
+
+        let pitchbend_change1 = MidiMessage::PitchBendChange {
+            channel,
+            value: 569
+        };
+
+        state.process_message(&pitchbend_change1);
+
+        assert_eq!(state.pitch_bend_values.get(&channel), Some(&569));
+
+        let pitchbend_change1 = MidiMessage::PitchBendChange {
+            channel,
+            value: 421
+        };
+
+        state.process_message(&pitchbend_change1);
+
+        assert_eq!(state.pitch_bend_values.get(&channel), Some(&421));
+    }
+}

--- a/testcfg.yml
+++ b/testcfg.yml
@@ -48,3 +48,22 @@ global_macros:
     actions:
       - type: key_sequence
         data: "ctrl+c"
+
+  - name: "precondition test"
+    matching_events:
+      - type: midi
+        data:
+          message_type: note_on
+          channel: 0
+          key: 65
+    required_preconditions:
+      - type: midi
+        data:
+          condition_type: note_on
+          channel: 0
+          key: 64
+    actions:
+      - type: enter_text
+        data: "Precondition works!"
+      - type: key_sequence
+        data: "Return"


### PR DESCRIPTION
This closes #6.

Implements Preconditions to actually do something beyond the nonfunctional placeholders that were there.

- Expands State/StateImpl to have a MidiState struct which keeps track of all the currently-pressed notes, known control, program, and pitch bend values. This can now also check if a given precondition matches against known state.

Preconditions can be built from config, and there are all the usual new unit tests covering this new functionality.