### PR TITLE
Introduce Control Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ including some future plans.
 
 ## To do:
 
-- Add some action enum types that allow control of the program (like exiting it, reloading config)
 - Investigate portability to non-linux platforms
+- See [Issues](https://github.com/michd/mmpd/issues)
 
 ## Dependencies
 

--- a/mmpd-bin/src/init.rs
+++ b/mmpd-bin/src/init.rs
@@ -83,7 +83,7 @@ fn get_default_config_file() -> Option<PathBuf> {
     )
 }
 
-fn get_config_file(cli_matches: Option<&ArgMatches>) -> Option<PathBuf> {
+pub (crate) fn get_config_file(cli_matches: Option<&ArgMatches>) -> Option<PathBuf> {
     const CONFIG_PARAM: &str = "config";
 
     let cli_config =
@@ -111,6 +111,13 @@ fn get_config_file(cli_matches: Option<&ArgMatches>) -> Option<PathBuf> {
 pub (crate) fn get_config(cli_matches: Option<&ArgMatches>) -> Option<(Config, String)> {
     // Get configuration file
     let config_file = get_config_file(cli_matches)?;
+    let config_file_copy = config_file.to_path_buf();
+    let config_file_name = config_file_copy.to_str().unwrap_or("[none]");
+
+    return Some((read_config(config_file)?, config_file_name.to_string()));
+}
+
+pub (crate) fn read_config(config_file: PathBuf) -> Option<Config> {
     let config_file_name = config_file.to_str().unwrap_or("[none]");
 
     // Read config file to text
@@ -139,7 +146,7 @@ pub (crate) fn get_config(cli_matches: Option<&ArgMatches>) -> Option<(Config, S
 
     // Process into Config object
     match intermediate_config.process() {
-        Ok(config) => Some((config, config_file_name.to_string())),
+        Ok(config) => Some(config),
 
         Err(e) => {
             eprintln!("Error: unable to parse config file {}", config_file_name);

--- a/mmpd-bin/src/main.rs
+++ b/mmpd-bin/src/main.rs
@@ -28,6 +28,13 @@ fn main() {
             }
         }
 
-        None => task_main(Some(&cli_matches))
+        None =>  {
+            // task_main returns `true` to indicate it should restart itself
+            let mut should_run_main = true;
+
+            while should_run_main {
+                should_run_main = task_main(Some(&cli_matches));
+            }
+        }
     }
 }

--- a/mmpd-bin/src/tasks/task_main.rs
+++ b/mmpd-bin/src/tasks/task_main.rs
@@ -1,23 +1,33 @@
 use clap::ArgMatches;
 use mmpd_lib::{focus, state};
-use mmpd_lib::macros::actions::ActionRunner;
-use mmpd_lib::macros::event_matching::get_event_bus;
-use crate::init::get_config;
+use mmpd_lib::macros::actions::{ActionRunner, ControlAction};
+use mmpd_lib::macros::event_matching::{get_event_bus, Event};
+use crate::init::{get_config_file, read_config};
 use crate::init::midi_setup::get_midi_setup;
+use std::sync::mpsc::Receiver;
+use mmpd_lib::config::Config;
+use mmpd_lib::state::State;
+use std::path::PathBuf;
 
-pub fn task_main(cli_matches: Option<&ArgMatches>) {
-    let config = get_config(cli_matches);
-
-    if config.is_none() {
-        return;
+pub fn task_main(cli_matches: Option<&ArgMatches>) -> bool {
+    let config_file = get_config_file(cli_matches);
+    if config_file.is_none() {
+        return false;
     }
 
-    let (config, config_filename) = config.unwrap();
+    let config_file = config_file.unwrap();
+    let config = read_config(config_file.to_path_buf());
+
+    if config.is_none() {
+        return false;
+    }
+
+    let config = config.unwrap();
 
     let midi_setup= get_midi_setup(cli_matches, Some(&config));
 
     if midi_setup.is_none() {
-        return;
+        return false;
     }
 
     let (mut midi_adapter, midi_device_name) = midi_setup.unwrap();
@@ -26,7 +36,7 @@ pub fn task_main(cli_matches: Option<&ArgMatches>) {
 
     if focus_adapter.is_none() {
         eprintln!("Unable to set up focus adapter - can't detect focused window.");
-        return;
+        return false;
     }
 
     let focus_adapter = focus_adapter.unwrap();
@@ -35,11 +45,10 @@ pub fn task_main(cli_matches: Option<&ArgMatches>) {
 
     if action_runner.is_none() {
         eprintln!("Unable to get an action runner.");
-        return;
+        return false;
     }
 
     let action_runner = action_runner.unwrap();
-    let mut state = state::new(focus_adapter);
 
     let (tx, rx) = get_event_bus();
     let handle = midi_adapter.start_listening(&midi_device_name, tx);
@@ -48,9 +57,30 @@ pub fn task_main(cli_matches: Option<&ArgMatches>) {
         eprintln!("Error: unable to start listening for MIDI events.");
     }
 
+    let config_filename = config_file.to_str().unwrap_or("[none]");
     println!("Starting mmpd.");
     println!("Using config file: {}", config_filename);
     println!("Listening for MIDI events on '{}'", midi_device_name);
+
+    print_macro_info(&config);
+
+    if config.macros.is_empty() {
+        return false;
+    }
+
+    // Now we've verified all the required data and conditions, we can kick off the main loop that
+    // does the work.
+    return main_loop(
+        config_file.to_path_buf(),
+        config,
+        state::new(focus_adapter),
+        rx,
+        action_runner
+    );
+}
+
+/// Prints info and help on macros found in config
+fn print_macro_info(config: &Config) {
     let macro_count = config.macros.len();
 
     if macro_count == 1 {
@@ -65,8 +95,20 @@ pub fn task_main(cli_matches: Option<&ArgMatches>) {
         println!("https://github.com/michd/mmpd/blob/main/docs/config.md");
 
         println!("\nSince there are no macros configured, there is nothing to do; exiting.");
-        return;
     }
+}
+
+fn main_loop(
+    config_file: PathBuf,
+    mut config: Config,
+    mut state: Box<dyn State>,
+    rx: Receiver<Event>,
+    action_runner: ActionRunner
+)-> bool {
+
+    let mut should_stop_rx_loop = false;
+    let mut should_restart = false;
+    let mut should_reload_config = false;
 
     for event in rx {
         state.process_event(&event);
@@ -80,13 +122,63 @@ pub fn task_main(cli_matches: Option<&ArgMatches>) {
                 }
 
                 for action in actions {
-                    // TODO: action_runner.run could return any actions that are for this main
-                    // application to evaluate, for control actions.
-                    action_runner.run(action);
+                    let control_action = action_runner.run(action);
+
+                    if let Some(control_action) = control_action {
+                        match control_action {
+                            ControlAction::ReloadMacros => {
+                                println!("Reloading macros from file");
+                                should_reload_config = true;
+                            }
+
+                            ControlAction::Restart => {
+                                println!("Restarting.");
+                                should_stop_rx_loop = true;
+                                should_restart = true;
+                            }
+
+                            ControlAction::Exit => {
+                                println!("Exiting.");
+                                should_stop_rx_loop = true;
+                                should_restart = false;
+                            }
+                        }
+                    }
                 }
 
                 break;
             }
         }
+
+        if should_reload_config {
+            should_reload_config = false;
+            let new_config = read_config(config_file.to_path_buf());
+
+            match new_config {
+                Some(new_config) => {
+                    config = new_config;
+                    println!("Reloaded config.");
+
+                    print_macro_info(&config);
+
+                    if config.macros.is_empty() {
+                        // No macros found, exit. print_macro_info prints a message to that
+                        // effect too.
+                        should_stop_rx_loop = true;
+                    }
+                }
+
+                None => eprintln!(
+                    "Failed to reload configured macros, \
+                    using previously loaded config's macros instead."
+                )
+            }
+        }
+
+        if should_stop_rx_loop {
+            break;
+        }
     }
+
+    return should_restart;
 }

--- a/mmpd-lib/src/config/versions/version1/actions.rs
+++ b/mmpd-lib/src/config/versions/version1/actions.rs
@@ -11,7 +11,7 @@ use key_sequence::build_action_key_sequence;
 use enter_text::build_action_enter_text;
 use shell::build_action_shell;
 use wait::build_action_wait;
-use crate::config::versions::version1::actions::control::build_action_control;
+use control::build_action_control;
 
 /// Constructs an `Action` from a `raw_action` `RCHash`.
 ///

--- a/mmpd-lib/src/config/versions/version1/actions/control.rs
+++ b/mmpd-lib/src/config/versions/version1/actions/control.rs
@@ -1,0 +1,159 @@
+use crate::config::raw_config::{RawConfig, AccessHelpers};
+use crate::macros::actions::{ControlAction, Action};
+use crate::config::ConfigError;
+
+pub fn build_action_control(raw_data: Option<&RawConfig>) -> Result<Action, ConfigError> {
+    const FIELD_ACTION: &str = "action";
+
+    const ACTION_RELOAD_MACROS: &str = "reload_macros";
+    const ACTION_RESTART: &str = "restart";
+    const ACTION_EXIT: &str = "exit";
+
+    let raw_data = raw_data.ok_or_else(|| {
+        ConfigError::InvalidConfig(
+            format!("Action control: missing data field")
+        )
+    })?;
+
+    let action_str = match raw_data {
+        RawConfig::String(raw_action) => Ok(raw_action.as_str()),
+
+        RawConfig::Hash(hash) => Ok(hash.get_string(FIELD_ACTION).ok_or_else(|| {
+                ConfigError::InvalidConfig(
+                    format!(
+                        "Action control: data field doesn't contain a string '{}' field",
+                        FIELD_ACTION
+                    )
+                )
+            })?),
+
+        _ => Err(ConfigError::InvalidConfig(
+            "Action control: data field should be either string or hash, but was neither"
+                .to_string()
+            ))
+    }?;
+
+    Ok(Action::Control(match action_str {
+        ACTION_RELOAD_MACROS => ControlAction::ReloadMacros,
+        ACTION_RESTART => ControlAction::Restart,
+        ACTION_EXIT => ControlAction::Exit,
+
+        _ => {
+            return Err(ConfigError::InvalidConfig(
+                format!(
+                    "Action control: Unknown control action '{}'",
+                    action_str
+                )
+            ));
+        }
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::raw_config::{RawConfig, k, RCHash};
+    use crate::config::versions::version1::actions::control::build_action_control;
+    use crate::macros::actions::{ControlAction, Action};
+
+    #[test]
+    fn builds_reload_macros_action_from_string() {
+        let data = k("reload_macros");
+
+        let action = build_action_control(Some(&data))
+            .ok().unwrap();
+
+        assert_eq!(action, Action::Control(ControlAction::ReloadMacros));
+    }
+
+    #[test]
+    fn builds_reload_macros_action_from_hash() {
+        let mut data = RCHash::new();
+        data.insert(k("action"), k("reload_macros"));
+
+        let action = build_action_control(Some(&RawConfig::Hash(data)))
+            .ok().unwrap();
+
+        assert_eq!(action, Action::Control(ControlAction::ReloadMacros));
+    }
+
+    #[test]
+    fn builds_restart_action_from_string() {
+        let data = k("restart");
+
+        let action = build_action_control(Some(&data))
+            .ok().unwrap();
+
+        assert_eq!(action, Action::Control(ControlAction::Restart));
+    }
+
+    #[test]
+    fn builds_restart_action_from_hash() {
+        let mut data = RCHash::new();
+        data.insert(k("action"), k("restart"));
+
+        let action = build_action_control(Some(&RawConfig::Hash(data)))
+            .ok().unwrap();
+
+        assert_eq!(action, Action::Control(ControlAction::Restart));
+    }
+
+    #[test]
+    fn builds_exit_action_from_string() {
+        let data = k("exit");
+
+        let action = build_action_control(Some(&data))
+            .ok().unwrap();
+
+        assert_eq!(action, Action::Control(ControlAction::Exit));
+    }
+
+    #[test]
+    fn builds_exit_action_from_hash() {
+        let mut data = RCHash::new();
+        data.insert(k("action"), k("exit"));
+
+        let action = build_action_control(Some(&RawConfig::Hash(data)))
+            .ok().unwrap();
+
+        assert_eq!(action, Action::Control(ControlAction::Exit));
+    }
+
+    #[test]
+    fn returns_error_if_data_is_none() {
+        let action = build_action_control(None);
+        assert!(action.is_err());
+    }
+
+    #[test]
+    fn returns_error_if_data_is_neither_string_nor_hash() {
+        let action = build_action_control(Some(&RawConfig::Null));
+        assert!(action.is_err());
+
+        let action = build_action_control(Some(&RawConfig::Bool(true)));
+        assert!(action.is_err());
+
+        let action = build_action_control(Some(&RawConfig::Integer(0)));
+        assert!(action.is_err());
+
+        let action = build_action_control(Some(&RawConfig::Array(vec![])));
+        assert!(action.is_err());
+    }
+
+    #[test]
+    fn returns_error_if_string_data_is_invalid_action() {
+        let action = build_action_control(Some(&RawConfig::String("InvalidAction".to_string())));
+        assert!(action.is_err());
+    }
+
+    #[test]
+    fn returns_error_if_data_is_hash_but_lacks_action_string_field() {
+        let data = RCHash::new();
+        let action = build_action_control(Some(&RawConfig::Hash(data)));
+        assert!(action.is_err());
+
+        let mut data = RCHash::new();
+        data.insert(k("action"), RawConfig::Null);
+        let action = build_action_control(Some(&RawConfig::Hash(data)));
+        assert!(action.is_err());
+    }
+}

--- a/testcfg.yml
+++ b/testcfg.yml
@@ -61,3 +61,57 @@ global_macros:
         data: "Precondition works!"
       - type: key_sequence
         data: "Return"
+
+  - name: "Exit mmpd"
+    matching_events:
+      - type: midi
+        data:
+          message_type: note_on
+          channel: 0
+          key: 41
+    required_preconditions:
+      - type: midi
+        data:
+          condition_type: control
+          channel: 0
+          control: 51
+          value: 127
+    actions:
+      - type: control
+        data: exit
+
+  - name: "Reload macros"
+    matching_events:
+      - type: midi
+        data:
+          message_type: note_on
+          channel: 0
+          key: 42
+    required_preconditions:
+      - type: midi
+        data:
+          condition_type: control
+          channel: 0
+          control: 51
+          value: 127
+    actions:
+      - type: control
+        data: reload_macros
+
+  - name: "Restart mmpd"
+    matching_events:
+      - type: midi
+        data:
+          message_type: note_on
+          channel: 0
+          key: 43
+    required_preconditions:
+      - type: midi
+        data:
+          condition_type: control
+          channel: 0
+          control: 51
+          value: 127
+    actions:
+      - type: control
+        data: restart


### PR DESCRIPTION
Adds a new type of Action, `Action::Control`, which allows controlling program flow.

- ReloadMacros: Attempts to reload config file for new / tweaked macros, ignores changes to MIDI device, maintains known state.
- Restart: As if restarting the program with the same arguments
- Exit: Terminates the program