### PR TITLE
MIDI events/preconditions: allow specifying `key` as a string like "D3"

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -31,6 +31,7 @@ global_macros:
     - [MIDI events](#midi-events)
     - [Value ranging](#value-ranging)
       - [MIDI](#midi)
+    - [Musical note matching](#musical-note-matching)
     - [Preconditions](#preconditions)
       - [MIDI Preconditions](#midi-preconditions)
     - [Actions](#actions)
@@ -151,7 +152,8 @@ key: 32,
     
 - `channel`: Optional. Which MIDI channel the event happens on. This is 0-based, so available channels are 0-15.
   See **value ranging** for how to specify matching values.
-- `key`: Optional. Which key number is relevant to the event. See **value ranging**.
+- `key`: Optional. Which key number is relevant to the event. See [Value ranging](#value-ranging), and
+  [Musical note matching](#musical-note-matching).
 - `velocity`: Optional. How fast a key was pressed down or released. See **value ranging**.
 
 The available properties depend on the value of `message_type`. Here is a comprehensive list:
@@ -220,6 +222,34 @@ key:
     max: 44
 ```
 will match keys 12, 14, and all the keys from 32 to 44 inclusive.
+
+#### Musical note matching
+
+For places where you're matching `key` field in a MIDI event matcher or precondition, you can use a string to match
+against a note name for convenience.
+
+Per example, with the usual syntax, you can match a note_on event for the key C3 as follows:
+
+```yaml
+message_type: note_on
+key: 48
+```
+
+Instead of counting or looking up note numbers, you can specify it this way, which is equivalent.
+
+```yaml
+message_type: note_on
+key: C3
+```
+
+Accidentals for flat (`b`) and sharp (`#`) are supported.
+
+There are two ways you can use the string notation:
+
+- Matching a single key: requires the note name like "C", "D#" + the octave number.
+- Matching a key in all octaves: requires the note name like "C", "D#", without an octave number; this will create a
+  number matcher matching all the keys in the MIDI note range matching the note name.
+  (This option was suggested by [@loansindi](https://github.com/loansindi).)
 
 ### Preconditions
 
@@ -297,7 +327,8 @@ list:
   - `channel` 0-15 inclusive
   - `value` 0-16383 inclusive
   
-Value ranging works the same way as it does for MIDI events, see **Value ranging** above.
+Value ranging works the same way as it does for MIDI events, see **Value ranging** above. For `note_on`'s `key`
+matcher, also see [Musical note matching](#musical-note-matching) for useful shorthands.
 
 ### Actions
 

--- a/mmpd-lib/src/config/versions/version1/event_matchers/midi.rs
+++ b/mmpd-lib/src/config/versions/version1/event_matchers/midi.rs
@@ -9,7 +9,7 @@ use crate::macros::event_matching::midi::MidiEventMatcher;
 /// ```yaml
 /// message_type: note_on
 /// channel: (number matcher)
-/// key: (number matcher)
+/// key: (number matcher | musical note string)
 /// velocity: (number matcher)
 /// ```
 ///
@@ -45,6 +45,11 @@ use crate::macros::event_matching::midi::MidiEventMatcher;
 /// - `pitch_bend_change` - Position of the pitch bender changes
 ///     - `channel`
 ///     - `value` - New pitch bend position (0-16383)
+///
+/// For `note_on`, `note_off`, and `poly_aftertouch`'s `key` field, you can specify a string
+/// describing a note, e.g.: "D#2", "A2", Bb1".
+/// You can also leave out the octave number, to create a number matcher matching that note on every
+/// octave, e.g.: "D#", "A", "Bb".
 ///
 /// ## Errors
 /// The function returns `ConfigError` in any of the following conditions:

--- a/mmpd-lib/src/config/versions/version1/event_matchers/midi.rs
+++ b/mmpd-lib/src/config/versions/version1/event_matchers/midi.rs
@@ -1,6 +1,6 @@
 use crate::config::raw_config::{RCHash, AccessHelpers, k};
 use crate::config::ConfigError;
-use crate::config::versions::version1::primitive_matchers::build_number_matcher;
+use crate::config::versions::version1::primitive_matchers::{build_number_matcher, build_musical_key_matcher};
 use crate::macros::event_matching::midi::MidiEventMatcher;
 
 /// Constructs a `MidiEventMatcher` from a `data` `RCHash`.
@@ -96,7 +96,7 @@ pub fn build_midi_event_matcher(
 
             MidiEventMatcher::NoteOn {
                 channel_match,
-                key_match: build_number_matcher(raw_key_matcher)?,
+                key_match: build_musical_key_matcher(raw_key_matcher)?,
                 velocity_match: build_number_matcher(raw_velocity_matcher)?
             }
         }
@@ -107,7 +107,7 @@ pub fn build_midi_event_matcher(
 
             MidiEventMatcher::NoteOff {
                 channel_match,
-                key_match: build_number_matcher(raw_key_matcher)?,
+                key_match: build_musical_key_matcher(raw_key_matcher)?,
                 velocity_match: build_number_matcher(raw_velocity_matcher)?
             }
         }
@@ -118,7 +118,7 @@ pub fn build_midi_event_matcher(
 
             MidiEventMatcher::PolyAftertouch {
                 channel_match,
-                key_match: build_number_matcher(raw_key_matcher)?,
+                key_match: build_musical_key_matcher(raw_key_matcher)?,
                 value_match: build_number_matcher(raw_value_matcher)?
             }
         }
@@ -175,7 +175,7 @@ pub fn build_midi_event_matcher(
 #[cfg(test)]
 mod tests {
     use crate::config::versions::version1::event_matchers::midi::build_midi_event_matcher;
-    use crate::config::raw_config::{RCHash, k, RawConfig};
+    use crate::config::raw_config::{RCHash, k, RawConfig, RCHashBuilder};
     use crate::macros::event_matching::midi::MidiEventMatcher;
     use crate::match_checker::NumberMatcher;
 
@@ -246,6 +246,24 @@ mod tests {
                 velocity_match: None
             }
         );
+
+        // With string key matcher
+        let hash = RCHashBuilder::new()
+            .insert(k("message_type"), k("note_on"))
+            .insert(k("key"), k("C3"))
+            .build();
+
+        let matcher = build_midi_event_matcher(Some(&hash))
+            .ok().unwrap();
+
+        assert_eq!(
+            matcher,
+            MidiEventMatcher::NoteOn {
+                channel_match: None,
+                key_match: Some(NumberMatcher::Val(48)),
+                velocity_match: None
+            }
+        );
     }
 
     #[test]
@@ -281,6 +299,25 @@ mod tests {
                 velocity_match: None
             }
         );
+
+        // With string key matcher
+        let hash = RCHashBuilder::new()
+            .insert(k("message_type"), k("note_off"))
+            .insert(k("key"), k("C3"))
+            .build();
+
+        let matcher = build_midi_event_matcher(Some(&hash))
+            .ok().unwrap();
+
+        assert_eq!(
+            matcher,
+            MidiEventMatcher::NoteOff {
+                channel_match: None,
+                key_match: Some(NumberMatcher::Val(48)),
+                velocity_match: None
+            }
+        );
+
     }
 
     #[test]
@@ -313,6 +350,24 @@ mod tests {
             MidiEventMatcher::PolyAftertouch {
                 channel_match: None,
                 key_match: None,
+                value_match: None
+            }
+        );
+
+        // With string key matcher
+        let hash = RCHashBuilder::new()
+            .insert(k("message_type"), k("poly_aftertouch"))
+            .insert(k("key"), k("C3"))
+            .build();
+
+        let matcher = build_midi_event_matcher(Some(&hash))
+            .ok().unwrap();
+
+        assert_eq!(
+            matcher,
+            MidiEventMatcher::PolyAftertouch {
+                channel_match: None,
+                key_match: Some(NumberMatcher::Val(48)),
                 value_match: None
             }
         );

--- a/mmpd-lib/src/config/versions/version1/precondition/midi.rs
+++ b/mmpd-lib/src/config/versions/version1/precondition/midi.rs
@@ -9,7 +9,7 @@ use crate::config::versions::version1::primitive_matchers::{build_number_matcher
 /// ```yaml
 /// condition_type: note_on
 /// channel: (number matcher)
-/// key: (number matcher)
+/// key: (number matcher | musical note string)
 /// ```
 ///
 /// This is just one example; there are different valid properties, depending on the value of
@@ -32,6 +32,10 @@ use crate::config::versions::version1::primitive_matchers::{build_number_matcher
 /// - `pitch_bend` - Position of the pitch bender, from "pitch_bend_change" messages
 ///     - `channel` - Which MIDI channel the pitch bend setting is on (0-15)
 ///     - `value` - What the last known pitch bend value is (0-16383)
+///
+/// For `note_on`'s `key` field, you can specify a string describing a note, e.g.: "D#2", "A2", Bb1".
+/// You can also leave out the octave number, to create a number matcher matching that note on every
+/// octave, e.g.: "D#", "A", "Bb".
 ///
 /// ## Errors
 /// The function returns `ConfigError` in any of the following conditions:

--- a/mmpd-lib/src/config/versions/version1/primitive_matchers.rs
+++ b/mmpd-lib/src/config/versions/version1/primitive_matchers.rs
@@ -1,5 +1,5 @@
 use crate::config::raw_config::{RCHash, RawConfig, AccessHelpers};
-use crate::match_checker::{StringMatcher, NumberMatcher};
+use crate::match_checker::{StringMatcher, NumberMatcher, NumMatch};
 use crate::config::ConfigError;
 use regex::Regex;
 use crate::midi;
@@ -42,7 +42,7 @@ use crate::midi;
 ///
 /// The function will return `ConfigError` if the field found is "regex", but the value specified
 /// fails to parse as a regular expression pattern.
-pub fn build_string_matcher(
+pub (crate) fn build_string_matcher(
     raw_matcher: Option<&RCHash>
 ) -> Result<Option<StringMatcher>, ConfigError> {
     if let None = raw_matcher { return Ok(None); }
@@ -119,7 +119,7 @@ pub fn build_string_matcher(
 ///
 /// All other cases of invalid data types and what have you return None rather
 /// than an error.
-pub fn build_number_matcher(matcher: Option<&RawConfig>) -> Result<Option<NumberMatcher>, ConfigError> {
+pub (crate) fn build_number_matcher(matcher: Option<&RawConfig>) -> Result<NumMatch, ConfigError> {
     const MIN_FIELD: &str = "min";
     const MAX_FIELD: &str = "max";
 
@@ -210,7 +210,7 @@ pub fn build_number_matcher(matcher: Option<&RawConfig>) -> Result<Option<Number
     }
 }
 
-pub fn build_number_matcher_from_musical_note(key_str: &str) -> Result<NumberMatcher, ConfigError> {
+pub (crate) fn build_number_matcher_from_musical_note(key_str: &str) -> Result<NumberMatcher, ConfigError> {
     let midi_notes = midi::parse_keys_from_str(key_str);
 
     if midi_notes.is_empty() {
@@ -234,6 +234,15 @@ pub fn build_number_matcher_from_musical_note(key_str: &str) -> Result<NumberMat
                 .collect()
         )
     })
+}
+
+pub (crate) fn build_musical_key_matcher(matcher: Option<&RawConfig>) -> Result<NumMatch, ConfigError> {
+    // Only do something different than regular number matcher if the matcher is for a string
+    if let Some(RawConfig::String(str_key)) = matcher {
+        return Ok(Some(build_number_matcher_from_musical_note(str_key.as_str())?));
+    }
+
+    return build_number_matcher(matcher);
 }
 
 #[cfg(test)]
@@ -480,8 +489,9 @@ mod number_matcher_tests {
 
 #[cfg(test)]
 mod musical_note_number_matcher_tests {
-    use crate::config::versions::version1::primitive_matchers::build_number_matcher_from_musical_note;
+    use crate::config::versions::version1::primitive_matchers::{build_number_matcher_from_musical_note, build_musical_key_matcher};
     use crate::match_checker::NumberMatcher;
+    use crate::config::raw_config::RawConfig;
 
     #[test]
     fn returns_error_on_invalid_key() {
@@ -525,5 +535,39 @@ mod musical_note_number_matcher_tests {
                 NumberMatcher::Val(123)
             ])
         );
+    }
+
+    #[test]
+    fn builds_key_matcher_from_string_rawconfig() {
+        let raw_matcher = RawConfig::String("C3".to_string());
+
+        let matcher = build_musical_key_matcher(Some(&raw_matcher))
+            .ok().unwrap();
+
+        assert_eq!(
+            matcher,
+            Some(NumberMatcher::Val(48))
+        );
+    }
+
+    #[test]
+    fn builds_regular_number_matcher_from_int_rawconfig() {
+        let raw_matcher = RawConfig::Integer(7);
+
+        let matcher = build_musical_key_matcher(Some(&raw_matcher))
+            .ok().unwrap();
+
+        assert_eq!(
+            matcher,
+            Some(NumberMatcher::Val(7))
+        );
+    }
+
+    #[test]
+    fn returns_none_for_none_matcher() {
+        let matcher = build_musical_key_matcher(None)
+            .ok().unwrap();
+
+        assert_eq!(matcher, None)
     }
 }

--- a/mmpd-lib/src/midi.rs
+++ b/mmpd-lib/src/midi.rs
@@ -123,7 +123,7 @@ fn parse_message(bytes: &[u8]) -> Option<MidiMessage> {
 
 /// Parses a string describing a note into MIDI note number(s)
 ///
-/// key_str should be in the format "<note name>[accidental][octave]" where angle brackets denote
+/// key_str should be in the format "<note name>[accidentals][octave]" where angle brackets denote
 /// required content, and square brackets optional content.
 ///
 /// Note name is a letter in the range A-G (case-independent)
@@ -164,7 +164,7 @@ pub fn parse_keys_from_str(key_str: &str) -> Vec<u8> {
     // Breaking apart the regular expression:
     // ^              - Start of input
     // ([A-Ga-g])     - Note name capture group: single char that's in range A-G or a-g, required
-    // ([b#]{1,100})? - Accidental capture group: single char that's either 'b' or '#', optional
+    // ([b#]{1,100})? - Accidental capture group: one or more chars that are either 'b' or '#', optional
     // (-?[0-9])?     - Octave capture group: single digit 0-9, may be prefixed with '-', optional
     // $              - End of input
     let key_regex = Regex::new(
@@ -187,7 +187,7 @@ pub fn parse_keys_from_str(key_str: &str) -> Vec<u8> {
     });
 
     // base_note_num is the number of the note if the octave were 0.
-    // C-1 is MIDI note 0, so C# starts at 12.
+    // C-1 is MIDI note 0, so C0 starts at 12.
     let base_note_num: i16 = match note_name.as_str() {
         "C" => 12,
         "D" => 14,
@@ -199,7 +199,7 @@ pub fn parse_keys_from_str(key_str: &str) -> Vec<u8> {
         _ => panic!("Invalid note name, which shouldn't be possible thanks to the regex")
     };
 
-    // Add offset if an accidental was given
+    // Add offset if any accidentals were specified
     let base_note_num = base_note_num + match accidentals {
         Some(accidentals) => {
             let flat_cnt = accidentals.chars().filter(|c| *c == 'b').count() as isize;

--- a/testcfg.yml
+++ b/testcfg.yml
@@ -26,7 +26,7 @@ global_macros:
         data:
           message_type: note_on
           channel: 0
-          key: 60
+          key: C
           velocity:
             min: 63
     actions:
@@ -68,7 +68,7 @@ global_macros:
         data:
           message_type: note_on
           channel: 0
-          key: 41
+          key: F2
     required_preconditions:
       - type: midi
         data:
@@ -86,7 +86,7 @@ global_macros:
         data:
           message_type: note_on
           channel: 0
-          key: 42
+          key: F#2
     required_preconditions:
       - type: midi
         data:
@@ -104,7 +104,7 @@ global_macros:
         data:
           message_type: note_on
           channel: 0
-          key: 43
+          key: G2
     required_preconditions:
       - type: midi
         data:


### PR DESCRIPTION
Closes #4.

 This PR adds support for what's described in #4, and then some. In addition to referring to single notes with a string, omitting the octave generates a number matcher that matches every existing note matching that note name (one in every octave covered by the MIDI note numbering scheme of 0-127).