### PR TITLE
Multiplatform: Mac OS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ behavior to keys and controllers, while differentiating based on the application
 
 Essentially, think of it as an additional keyboard that does custom things based on what application you're working with.
 
-You can of course also set up actions that work regardless of the application.
+You can also set up "global" actions that work regardless of the application.
 
-Initially written for use on Linux distributions using the X windowing system, it is structured with
-the intent to allow implementing it for other platforms, though this has not been done yet.
+Initially written for use on Linux distributions using the X windowing system, it was structured to easily allow
+adding implementations for other platforms. At the moment, Linux with X windowing system, Windows, and Mac OS are
+supported. The Mac OS implementation is quite slow since it works through shell calls to `osascript`. It's an area that
+could do with improvement, perhaps through rust bindings to the CoreGraphics library.
 
 ## Current status: tentatively ready for some use
 
@@ -33,6 +35,7 @@ What's implemented so far:
   - list-midi-devices subcommand
   - monitor subcommand (to view incoming events without running macros)
   - (no subcommand) listening for events and running configured macros in response
+- Support for Linux (using X server), Windows, and Mac OS
 
 There's documentation on the configuration format in [docs/config.md](https://github.com/michd/midi-macro-pad/blob/main/docs/config.md)
 including some future plans.
@@ -52,3 +55,7 @@ including some future plans.
 ### Windows
 
 Nothing specific I think, but see [Installing `rustup` on Windows](https://doc.rust-lang.org/stable/book/ch01-01-installation.html#installing-rustup-on-windows).
+
+### Mac OS
+
+Nothing specific. Mac OS-specific parts interface with the system through AppleScript.

--- a/docs/config.md
+++ b/docs/config.md
@@ -365,14 +365,24 @@ data:
   delay: 1500
 ```
 
-- `sequence`: Required. A string representing the key combination. Key symbols are those from X Keysyms. A list may be
-  found in the X11 source code file for [keysymdef.h](https://code.woboq.org/kde/include/X11/keysymdef.h.html).
-  The symbols to use are the `XK_`-prefixed ones, without that prefix. To use multiple key sequences in a row, you can
+- `sequence`: Required. A string representing the key combination.
+  
+  - On Linux and Windows, key symbols are those from X Keysyms. A list may be found in the X11 source code file for
+  [keysymdef.h](https://code.woboq.org/kde/include/X11/keysymdef.h.html). The symbols to use are the `XK_`-prefixed ones,
+  without that prefix.
+  - On Mac OS, some different key names like "control", "option", "command" are available. The same syntax with `+`
+    still applies, but the key names differ. This is a good reference for the names of keys: 
+    [Complete list of AppleScript keycodes](https://eastmanreference.com/complete-list-of-applescript-key-codes).
+    As an example, these are valid: `"command+t"`, `"command+shift+option+a"`
+    
+  To use multiple key sequences in a row, you can
   space-separate them like `"ctrl+shift+t Tab Tab Return"`
 - `count`: Optional, defaults to 1. How many times to repeat entering this sequence.
-- `delay`: Optional, defaults to 100. How many microseconds to wait between key presses. 
+- `delay`: Optional, defaults to 100. How many microseconds to wait between key presses.
+  On Mac OS, this is not used.
 - `delay_ms`: Optional, shorthand for `delay` for larger values. How many milliseconds to wait between key presses.
-  If both `delay` and `delay_ms` have valid values, the value for `delay` is used.
+  If both `delay` and `delay_ms` have valid values, the value for `delay` is used. On Mac OS, neither `delay` nor
+  `delay_ms` are used.
 
 #### enter_text
 
@@ -389,9 +399,10 @@ data:
 
 - `text`: Required. String containing text exactly as you'd like it "typed" into the focused application.
 - `count`: Optional, defaults to 1. How many times to repeat entering this sequence.
-- `delay`: Optional, defaults to 100. How many microseconds to wait between key presses.
+- `delay`: Optional, defaults to 100. How many microseconds to wait between key presses. On Mac OS, this is not used.
 - `delay_ms`: Optional, shorthand for `delay` for larger values. How many milliseconds to wait between key presses.
-  If both `delay` and `delay_ms` have valid values, the value for `delay` is used.
+  If both `delay` and `delay_ms` have valid values, the value for `delay` is used. On Mac OS, neither `delay` nor
+  `delay_ms` are used.
 
 ##### Shortened version
 

--- a/mmpd-lib/src/focus.rs
+++ b/mmpd-lib/src/focus.rs
@@ -10,6 +10,12 @@ mod windows;
 #[cfg(target_os = "windows")]
 pub use windows::get_adapter;
 
+#[cfg(target_os = "macos")]
+mod mac_os;
+
+#[cfg(target_os = "macos")]
+pub use mac_os::get_adapter;
+
 /// Container struct for window info
 #[derive(Debug)]
 pub struct FocusedWindow {

--- a/mmpd-lib/src/focus/mac_os.rs
+++ b/mmpd-lib/src/focus/mac_os.rs
@@ -1,0 +1,20 @@
+use crate::focus::{FocusAdapter, FocusedWindow};
+
+pub fn get_adapter() -> Option<Box<impl FocusAdapter>> {
+    MacOs::new().map(|mac_os| Box::new(mac_os))
+}
+
+struct MacOs {}
+
+impl MacOs {
+    fn new() -> Option<impl FocusAdapter> {
+        Some(MacOs {})
+    }
+}
+
+impl FocusAdapter for MacOs {
+    fn get_focused_window(&self) -> Option<FocusedWindow> {
+        println!("Todo: get_focused_window on MacOs");
+        None
+    }
+}

--- a/mmpd-lib/src/focus/mac_os/get_window_info.scpt
+++ b/mmpd-lib/src/focus/mac_os/get_window_info.scpt
@@ -1,0 +1,26 @@
+#!/usr/bin/osascript
+-- With thanks to this StackOverflow answer by Albert
+-- https://stackoverflow.com/a/5293758/1019228
+
+global frontApp, frontAppName, frontAppClass, windowTitle
+set windowTitle to ""
+
+tell application "System Events"
+    -- Get the focused application
+    set frontApp to first application process whose frontmost is true
+    -- Grab name and display name of focused application, these will
+    -- be the values we populate window_class with
+    set frontAppName to name of frontApp
+    set frontAppClass to displayed name of frontApp
+
+    -- Get the window title
+    tell process frontAppName
+        tell (1st window whose value of attribute "AXMain" is true)
+            set windowTitle to value of attribute "AXTitle"
+        end tell
+    end tell
+
+end tell
+
+-- Print app class, app name, and window title to STDOUT on their own lines
+copy frontAppClass & "\n" & frontAppName & "\n" & windowTitle to stdout

--- a/mmpd-lib/src/keyboard_control.rs
+++ b/mmpd-lib/src/keyboard_control.rs
@@ -10,6 +10,12 @@ mod windows;
 #[cfg(target_os = "windows")]
 pub use windows::get_adapter;
 
+#[cfg(target_os = "macos")]
+mod mac_os;
+
+#[cfg(target_os = "macos")]
+pub use mac_os::get_adapter;
+
 use std::fmt::{self, Display, Formatter};
 
 /// Adapters implementing this trait can send key sequences and text as if they were entered on

--- a/mmpd-lib/src/keyboard_control.rs
+++ b/mmpd-lib/src/keyboard_control.rs
@@ -16,6 +16,11 @@ mod mac_os;
 #[cfg(target_os = "macos")]
 pub use mac_os::get_adapter;
 
+#[cfg(test)]
+use mockall::*;
+#[cfg(test)]
+use mockall::predicate::*;
+
 use std::fmt::{self, Display, Formatter};
 
 /// Adapters implementing this trait can send key sequences and text as if they were entered on
@@ -38,6 +43,7 @@ pub trait KeyboardControlAdapter {
 pub type KeyboardResult = Result<(), KeyboardControlError>;
 
 /// Errors that may occur when trying to use a KeyboardControlAdapter
+#[derive(Debug)]
 pub enum KeyboardControlError {
     /// An unknown/unsupported/invalid key was passed to `send_keysequence`
     InvalidKey(

--- a/mmpd-lib/src/keyboard_control/mac_os.rs
+++ b/mmpd-lib/src/keyboard_control/mac_os.rs
@@ -1,4 +1,5 @@
 use crate::keyboard_control::{KeyboardControlAdapter, KeyboardResult, KeyboardControlError};
+use std::process::Command;
 
 pub fn get_adapter() -> Option<Box<impl KeyboardControlAdapter>> {
     MacOs::new().map(|mac_os| Box::new(mac_os))
@@ -13,19 +14,61 @@ impl MacOs {
 }
 
 impl KeyboardControlAdapter for MacOs {
-    fn send_keysequence(&self, _sequence: &str, _delay_microsecs: u32) -> KeyboardResult {
+    // Note: this implementation leaves much to be desired.
+    // 1) It's incredibly slow, especially when running multiple calls of this in a row;
+    //    each one is a full new invocation of osascript. This could be much improved if
+    //    multiple keysequence actions were combined into one, in some way, so that the Mac OS
+    //    implementation could generate and run a single script to run all of them.
+    // 2) It would be nicer if we could use proper Apple SDK (like CoreGraphics events) calls
+    //    instead of doing it in the hacky AppleScript way. Unfortunately, existing binding
+    //    projects don't appear to offer adequate coverage yet, and contributing to that scale
+    //    of rust access is a bit beyond the scope of this project for me (MichD); I'm just
+    //    implementing support for Mac OS, an OS I have no intention of spending any appreciable
+    //    time using, for the sake of having this project be properly multi-platform.
+    //
+    // Anyway, some ideas, that would take this outside of this module: We could pre-process
+    // a list of actions found in a macro upon loading config, and repackage a series of
+    // key sequence actions into a MacOS-only "AppleScript" wrapper action to make this a lot
+    // more efficient. The AppleScript action does not need to be accessible from the config file
+    // directly though; best to keep it internal.
+    fn send_keysequence(&self, sequence: &str, _delay_microsecs: u32) -> KeyboardResult {
         // See https://eastmanreference.com/complete-list-of-applescript-key-codes
         // And https://eastmanreference.com/how-to-automate-your-keyboard-in-mac-os-x-with-applescript
-        println!("Todo: send_keysequence in MacOs");
-        Ok(())
+        let sequence_script = build_sequence_script(sequence)?;
+
+        Command::new("osascript")
+            .arg("-e")
+            .arg(format!("tell application \"System Events\" to {}", sequence_script))
+            .status()
+            .map(|_| ())
+            .map_err(|err| KeyboardControlError::Other(err.to_string()))
     }
 
-    fn send_text(&self, _text: &str, _delay_microsecs: u32) -> KeyboardResult {
-        println!("Todo: send_text in MacOs");
-        Ok(())
+    fn send_text(&self, text: &str, _delay_microsecs: u32) -> KeyboardResult {
+        // Note: the text input is passed as an argument instead of concatenated into the script
+        // to allow proper handling of the data, thereby ensuring there's no opportunity for
+        // the context of text to become arbitrary apple script that can be executed.
+        // To run arbitrary code, Action::Shell should be used instead.
+
+        let script = r#"
+            on run argv
+                tell application "System Events"
+                    keystroke item 1 of argv
+                end tell
+            end run
+        "#;
+
+        Command::new("osascript")
+            .arg("-e")
+            .arg(script)
+            .arg(text)
+            .status()
+            .map(|_| ())
+            .map_err(|err| KeyboardControlError::Other(err.to_string()))
     }
 }
 
+/// Builds the line of AppleScript that will execute a key combination
 fn build_sequence_script(str_sequence: &str) -> Result<String, KeyboardControlError> {
     let str_sequence = str_sequence.trim();
 
@@ -33,44 +76,200 @@ fn build_sequence_script(str_sequence: &str) -> Result<String, KeyboardControlEr
         return Err(KeyboardControlError::Other("No keys specified".to_string()));
     }
 
+    // Split on `+` and trim each found key
     let keys= str_sequence.split('+')
         .into_iter()
         .map(|key| key.trim().to_string())
         .collect::<Vec<String>>();
 
-    const CMD_PREFIX: &str = "keystroke";
-
+    // Different numbers of keys call for different AppleScript syntax
     Ok(match keys.len() {
+        // This seems very unlikely to occur given the is_empty check above
         0 => return Err(KeyboardControlError::Other("No keys specified".to_string())),
 
         // Unwrap is safe since length was checked
-        1 => format!("{} {}", CMD_PREFIX, keys.first().unwrap()),
+        // "keystroke <key>" or "key code <key code>"
+        1 => build_main_key_subcommand(keys.first().unwrap())?,
 
         // Unwrap is again safe since length was checked
+        // "keystroke <key> using <other key> down"
         2 => format!(
-            "{} {} using {} down",
-            CMD_PREFIX,
-            keys.last().unwrap(),
+            "{} using {} down",
+            build_main_key_subcommand(keys.last().unwrap())?,
             keys.first().unwrap()
         ),
 
         // > 2
+        // "keystroke <key> using {<other key 1> down, <other key 2> down[...]}"
         _ => {
             let held_keys = &keys[0..keys.len() - 1]
                 .iter()
                 .rev()
                 .map(|s| format!("{} down", s))
                 .collect::<Vec<String>>()
-                .join(", ").to_string();
+                .join(", ")
+                .to_string();
 
             format!(
-                "{} {} using {{{}}}",
-                CMD_PREFIX,
-                keys.last().unwrap(),
+                "{} using {{{}}}",
+                build_main_key_subcommand(keys.last().unwrap())?,
                 held_keys
             )
         }
     })
+}
+
+/// Builds the first part of a keystroke AppleScript command from a given key string
+/// This function determines whether the command should use `key code` or `keystroke`, and
+/// translates accordingly. Can return KeyBoardControlError if an invalid key is specified.
+fn build_main_key_subcommand(key: &str) -> Result<String, KeyboardControlError> {
+    // Key values that need to be provided to `keystroke` as a quoted string
+    const QUOTED_KEYSTROKE_INPUTS: &'static [&str] = &[
+        "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "l", "m", "n", "o", "p", "q", "r", "s",
+        "t", "u", "v", "w", "x", "y", "z", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "¬",
+        "`", "!", r#"""#, "£", "$", "%", "^", "&", "*", "(", ")", "-", "_", "+", "=", "[", "]", "{",
+        "}", ":", ";", "@", "'", "#", "~", r#"\"#, "|", ",", ".", "<", ">", "/", "?",
+    ];
+
+    // Key values that may be provided via `keystroke` without quotes
+    const VALID_OTHER_KEYS: &'static [&str] = &[
+        "control", "option", "shift", "command", "tab", "space"
+    ];
+
+    let key = key.to_lowercase();
+
+    // Check if the input key is one in the list that needs quoting for `keystroke`
+    if QUOTED_KEYSTROKE_INPUTS.contains(&key.as_str()) {
+        let key = match key.as_str() {
+            // Escape madness, woo
+            r#"""# => r#"\""#, // If the character is ", escape it.
+            r#"\"# => r#"\\"#, // If the character is \, escape it.
+            _ => key.as_str() // If none of those special cases, use it as-is
+        };
+
+        return Ok(format!("keystroke \"{}\"", key))
+    }
+
+    // If the key didn't match one of the values that need quoting, check if it matches a value
+    // that needs to be represented as a `key code`, and grab the corresponding key code.
+    let key_code = match key.as_str() {
+        "enter" => Some(76),
+        "return" => Some(36),
+        "esc" => Some(53),
+        "left" => Some(123),
+        "right" => Some(124),
+        "up" => Some(126),
+        "down" => Some(125),
+        "home" => Some(115),
+        "end" => Some(119),
+        "page_up" => Some(116),
+        "page_down" => Some(121),
+        "f1" => Some(122),
+        "f2" => Some(120),
+        "f3" => Some(99),
+        "f4" => Some(118),
+        "f5" => Some(96),
+        "f6" => Some(97),
+        "f7" => Some(98),
+        "f8" => Some(100),
+        "f9" => Some(101),
+        "f10" => Some(109),
+        "f11" => Some(103),
+        "f12" => Some(111),
+        "f13" => Some(105),
+        "f14" => Some(107),
+        "f15" => Some(113),
+        "f16" => Some(106),
+        "f17" => Some(64),
+        "f18" => Some(79),
+        "f19" => Some(80),
+        "f20" => Some(90),
+        _ => None
+    };
+
+    // If the key matched one of the key codes in the above list, build the command with the result
+    if let Some(code) = key_code {
+        return Ok(format!("key code {}", code));
+    }
+
+    // Lastly, if none of that matched yet, see if the key is a valid key that can be used
+    // unquoted, otherwise, return an error
+    if VALID_OTHER_KEYS.contains(&key.as_str()) {
+        Ok(format!("keystroke {}", key))
+    } else {
+        Err(KeyboardControlError::InvalidKey(key))
+    }
+}
+
+#[cfg(test)]
+mod build_main_key_subcommand_tests {
+    use crate::keyboard_control::mac_os::build_main_key_subcommand;
+
+    #[test]
+    fn builds_keystrokes_that_need_quoting() {
+        assert_eq!(
+            r#"keystroke "a""#,
+            build_main_key_subcommand("a").unwrap()
+        );
+    }
+
+    #[test]
+    fn ignores_case_for_keystrokes_that_need_quoting() {
+        assert_eq!(
+            r#"keystroke "a""#,
+            build_main_key_subcommand("A").unwrap()
+        )
+    }
+
+    #[test]
+    fn builds_keystrokes_that_need_keycode() {
+        assert_eq!(
+            "key code 116",
+            build_main_key_subcommand("page_up").unwrap()
+        );
+    }
+
+    #[test]
+    fn ignores_case_for_keystrokes_that_need_keycode() {
+        assert_eq!(
+            "key code 116",
+            build_main_key_subcommand("Page_Up").unwrap()
+        );
+    }
+
+    #[test]
+    fn correctly_escapes_double_quote_and_backslash() {
+        assert_eq!(
+            r#"keystroke "\"""#,
+            build_main_key_subcommand(r#"""#).unwrap()
+        );
+
+        assert_eq!(
+            r#"keystroke "\\""#,
+            build_main_key_subcommand(r#"\"#).unwrap()
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_multi_character_keys() {
+        assert!(build_main_key_subcommand("notakey").is_err());
+    }
+
+    #[test]
+    fn accepts_valid_multi_character_keys() {
+        assert_eq!(
+            "keystroke command",
+            build_main_key_subcommand("command").unwrap()
+        );
+    }
+
+    #[test]
+    fn ignores_case_in_valid_multi_character_keys() {
+        assert_eq!(
+            "keystroke command",
+            build_main_key_subcommand("Command").unwrap()
+        );
+    }
 }
 
 #[cfg(test)]
@@ -79,46 +278,39 @@ mod build_sequence_scrip_tests {
 
     #[test]
     fn fails_on_blank_string() {
-        let input = " ";
-
-        let output = build_sequence_script(input);
-
-        assert!(output.is_err());
+        assert!(build_sequence_script("").is_err());
+        assert!(build_sequence_script(" ").is_err());
     }
 
     #[test]
     fn forms_single_key_sequence_command() {
-        let input = "a";
-
-        let output = build_sequence_script(input).unwrap();
-
-        assert_eq!("keystroke a".to_string(), output);
+        assert_eq!(
+            r#"keystroke "a""#.to_string(),
+            build_sequence_script("a").unwrap()
+        );
     }
 
     #[test]
     fn forms_double_key_sequence_command() {
-        let input: &str = "a+b";
-
-        let output = build_sequence_script(input).unwrap();
-
-        assert_eq!("keystroke b using a down".to_string(), output);
+        assert_eq!(
+            r#"keystroke "b" using a down"#.to_string(),
+            build_sequence_script("a+b").unwrap()
+        );
     }
 
     #[test]
     fn forms_triple_key_sequence_command() {
-        let input: &str = "a+b+c";
-
-        let output = build_sequence_script(input).unwrap();
-
-        assert_eq!("keystroke c using {b down, a down}".to_string(), output);
+        assert_eq!(
+            r#"keystroke "c" using {b down, a down}"#.to_string(),
+            build_sequence_script("a+b+c").unwrap()
+        );
     }
 
     #[test]
     fn forms_quadruple_key_sequence_command() {
-        let input: &str = "aa+bb+cc+dd";
-
-        let output = build_sequence_script(input).unwrap();
-
-        assert_eq!("keystroke dd using {cc down, bb down, aa down}".to_string(), output);
+        assert_eq!(
+            r#"keystroke "d" using {c down, b down, a down}"#.to_string(),
+            build_sequence_script("a+b+c+d").unwrap()
+        );
     }
 }

--- a/mmpd-lib/src/keyboard_control/mac_os.rs
+++ b/mmpd-lib/src/keyboard_control/mac_os.rs
@@ -1,0 +1,25 @@
+use crate::keyboard_control::{KeyboardControlAdapter, KeyboardResult, KeyboardControlError};
+
+pub fn get_adapter() -> Option<Box<impl KeyboardControlAdapter>> {
+    MacOs::new().map(|mac_os| Box::new(mac_os))
+}
+
+struct MacOs {}
+
+impl MacOs {
+    fn new() -> Option<impl KeyboardControlAdapter> {
+        Some(MacOs {})
+    }
+}
+
+impl KeyboardControlAdapter for MacOs {
+    fn send_keysequence(&self, _sequence: &str, _delay_microsecs: u32) -> KeyboardResult {
+        println!("Todo: send_keysequence in MacOs");
+        Ok(())
+    }
+
+    fn send_text(&self, _text: &str, _delay_microsecs: u32) -> KeyboardResult {
+        println!("Todo: send_text in MacOs");
+        Ok(())
+    }
+}

--- a/mmpd-lib/src/keyboard_control/mac_os.rs
+++ b/mmpd-lib/src/keyboard_control/mac_os.rs
@@ -14,6 +14,8 @@ impl MacOs {
 
 impl KeyboardControlAdapter for MacOs {
     fn send_keysequence(&self, _sequence: &str, _delay_microsecs: u32) -> KeyboardResult {
+        // See https://eastmanreference.com/complete-list-of-applescript-key-codes
+        // And https://eastmanreference.com/how-to-automate-your-keyboard-in-mac-os-x-with-applescript
         println!("Todo: send_keysequence in MacOs");
         Ok(())
     }
@@ -21,5 +23,102 @@ impl KeyboardControlAdapter for MacOs {
     fn send_text(&self, _text: &str, _delay_microsecs: u32) -> KeyboardResult {
         println!("Todo: send_text in MacOs");
         Ok(())
+    }
+}
+
+fn build_sequence_script(str_sequence: &str) -> Result<String, KeyboardControlError> {
+    let str_sequence = str_sequence.trim();
+
+    if str_sequence.is_empty() {
+        return Err(KeyboardControlError::Other("No keys specified".to_string()));
+    }
+
+    let keys= str_sequence.split('+')
+        .into_iter()
+        .map(|key| key.trim().to_string())
+        .collect::<Vec<String>>();
+
+    const CMD_PREFIX: &str = "keystroke";
+
+    Ok(match keys.len() {
+        0 => return Err(KeyboardControlError::Other("No keys specified".to_string())),
+
+        // Unwrap is safe since length was checked
+        1 => format!("{} {}", CMD_PREFIX, keys.first().unwrap()),
+
+        // Unwrap is again safe since length was checked
+        2 => format!(
+            "{} {} using {} down",
+            CMD_PREFIX,
+            keys.last().unwrap(),
+            keys.first().unwrap()
+        ),
+
+        // > 2
+        _ => {
+            let held_keys = &keys[0..keys.len() - 1]
+                .iter()
+                .rev()
+                .map(|s| format!("{} down", s))
+                .collect::<Vec<String>>()
+                .join(", ").to_string();
+
+            format!(
+                "{} {} using {{{}}}",
+                CMD_PREFIX,
+                keys.last().unwrap(),
+                held_keys
+            )
+        }
+    })
+}
+
+#[cfg(test)]
+mod build_sequence_scrip_tests {
+    use crate::keyboard_control::mac_os::build_sequence_script;
+
+    #[test]
+    fn fails_on_blank_string() {
+        let input = " ";
+
+        let output = build_sequence_script(input);
+
+        assert!(output.is_err());
+    }
+
+    #[test]
+    fn forms_single_key_sequence_command() {
+        let input = "a";
+
+        let output = build_sequence_script(input).unwrap();
+
+        assert_eq!("keystroke a".to_string(), output);
+    }
+
+    #[test]
+    fn forms_double_key_sequence_command() {
+        let input: &str = "a+b";
+
+        let output = build_sequence_script(input).unwrap();
+
+        assert_eq!("keystroke b using a down".to_string(), output);
+    }
+
+    #[test]
+    fn forms_triple_key_sequence_command() {
+        let input: &str = "a+b+c";
+
+        let output = build_sequence_script(input).unwrap();
+
+        assert_eq!("keystroke c using {b down, a down}".to_string(), output);
+    }
+
+    #[test]
+    fn forms_quadruple_key_sequence_command() {
+        let input: &str = "aa+bb+cc+dd";
+
+        let output = build_sequence_script(input).unwrap();
+
+        assert_eq!("keystroke dd using {cc down, bb down, aa down}".to_string(), output);
     }
 }

--- a/mmpd-lib/src/keyboard_control/mac_os.rs
+++ b/mmpd-lib/src/keyboard_control/mac_os.rs
@@ -77,7 +77,7 @@ fn build_sequence_script(str_sequence: &str) -> Result<String, KeyboardControlEr
     }
 
     // Split on `+` and trim each found key
-    let keys= str_sequence.split('+')
+    let keys = str_sequence.split('+')
         .into_iter()
         .map(|key| key.trim().to_string())
         .collect::<Vec<String>>();

--- a/mmpd-lib/src/macros/actions.rs
+++ b/mmpd-lib/src/macros/actions.rs
@@ -199,7 +199,7 @@ impl ActionRunner {
 #[cfg(test)]
 mod tests {
     use crate::macros::actions::{ActionRunner, Action, DELAY_BETWEEN_KEYS_US, ControlAction};
-    use crate::keyboard_control::adapters::MockKeyboardControlAdapter;
+    use crate::keyboard_control::MockKeyboardControlAdapter;
     use crate::shell::{Shell, MockShell};
     use mockall::predicate::eq;
     use crate::keyboard_control::KeyboardControlAdapter;
@@ -245,7 +245,7 @@ mod tests {
         mock_keyb_adapter.expect_send_keysequence()
             .with(eq("ctrl+alt+delete"), eq(DELAY_BETWEEN_KEYS_US))
             .times(1)
-            .return_const(());
+            .returning(|_, _| Ok(()));
 
         let runner = ActionRunnerBuilder::new()
             .set_keyboard_adapter(Box::new(mock_keyb_adapter))
@@ -263,7 +263,7 @@ mod tests {
         mock_keyb_adapter.expect_send_keysequence()
             .with(eq("Tab"), eq(DELAY_BETWEEN_KEYS_US))
             .times(3)
-            .return_const(());
+            .returning(|_, _| Ok(()));
 
         let runner = ActionRunnerBuilder::new()
             .set_keyboard_adapter(Box::new(mock_keyb_adapter))
@@ -285,17 +285,17 @@ mod tests {
         mock_keyb_adapter.expect_send_keysequence()
             .with(eq("ctrl+t"), eq(DELAY_BETWEEN_KEYS_US))
             .times(1)
-            .return_const(());
+            .returning(|_, _| Ok(()));
 
         mock_keyb_adapter.expect_send_keysequence()
             .with(eq("Tab"), eq(DELAY_BETWEEN_KEYS_US))
             .times(2)
-            .return_const(());
+            .returning(|_, _| Ok(()));
 
         mock_keyb_adapter.expect_send_keysequence()
             .with(eq("Return"), eq(DELAY_BETWEEN_KEYS_US))
             .times(1)
-            .return_const(());
+            .returning(|_, _| Ok(()));
 
         let runner = ActionRunnerBuilder::new()
             .set_keyboard_adapter(Box::new(mock_keyb_adapter))
@@ -318,17 +318,17 @@ mod tests {
         mock_keyb_adapter.expect_send_keysequence()
             .with(eq("ctrl+t"), eq(DELAY_BETWEEN_KEYS_US))
             .times(3)
-            .return_const(());
+            .returning(|_, _| Ok(()));
 
         mock_keyb_adapter.expect_send_keysequence()
             .with(eq("Tab"), eq(DELAY_BETWEEN_KEYS_US))
             .times(6)
-            .return_const(());
+            .returning(|_, _| Ok(()));
 
         mock_keyb_adapter.expect_send_keysequence()
             .with(eq("Return"), eq(DELAY_BETWEEN_KEYS_US))
             .times(3)
-            .return_const(());
+            .returning(|_, _| Ok(()));
 
         let runner = ActionRunnerBuilder::new()
             .set_keyboard_adapter(Box::new(mock_keyb_adapter))
@@ -351,7 +351,7 @@ mod tests {
         mock_keyb_adapter.expect_send_text()
             .with(eq("hello"), eq(DELAY_BETWEEN_KEYS_US))
             .times(1)
-            .return_const(());
+            .returning(|_, _| Ok(()));
 
         let runner = ActionRunnerBuilder::new()
             .set_keyboard_adapter(Box::new(mock_keyb_adapter))
@@ -369,7 +369,7 @@ mod tests {
         mock_keyb_adapter.expect_send_text()
             .with(eq("hello"), eq(DELAY_BETWEEN_KEYS_US))
             .times(3)
-            .return_const(());
+            .returning(|_, _| Ok(()));
 
         let runner = ActionRunnerBuilder::new()
             .set_keyboard_adapter(Box::new(mock_keyb_adapter))

--- a/mmpd-lib/src/macros/actions.rs
+++ b/mmpd-lib/src/macros/actions.rs
@@ -9,22 +9,28 @@ use regex::Regex;
 pub enum Action {
     /// Sends a key sequence 0 or more times
     /// Use this one for key combinations.
-    /// The str argument specifies the key sequence, according to X Keysym notation.
-    /// Per example "ctrl+shift+t": emulates pressing the "Ctrl", "Shift" and "t" keys at
-    /// the same time.
-    /// The number is how many times this key sequence should be entered.
     KeySequence {
+        /// Key sequence, on Linux and Windows according to X Keysym notation, on Mac OS not quite
+        /// but close. (Uses "command", "control", "option" instead, otherwise largely the same)
         sequence: String,
+
+        /// How many times this sequence should be entered
         count: usize,
+
+        /// Delay time in microseconds between keystrokes, not applicable on Mac OS
         delay: Option<u32>
     },
 
     /// Enters text as if you typed it on a keyboard
     /// Use this one for text exactly as in the string provided.
-    /// The number is how many times this same string should be entered.
     EnterText {
+        /// Text to be entered as if typed on keyboard
         text: String,
+
+        /// How many times this text should be repeated
         count: usize,
+
+        /// Delay time in microseconds between keystrokes, not applicable on Mac OS
         delay: Option<u32>
     },
 


### PR DESCRIPTION
This PR adds support for Mac OS.

Both `FocusAdapter` and `KeyboardControlAdapter` are implemented through shell calls to `osascript`, so the implementation is essentially done in AppleScript.

A better way would be through the CoreGraphics SDK, but after quite a bit of research, I couldn't find any existing bindings that included the methods and/or structs required for this implementation.

While this implementation has its drawbacks (speed, for one major thing), it does provide almost full support for all the features that work on other platforms. Delay between keypresses is not supported, though it's very likely not necessary. `Wait` action do work, but those are not platform-specific.