### PR TITLE
Scopes: Allow setting scopes based on window's executable path / filename

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -51,14 +51,19 @@ global_macros:
 
 ## Scopes
 
-A scope consists of a pattern to match a focused application window's title and/or window class, and a list of
-associated macros that only apply if a window matching the pattern is currently focused. A scope looks like this:
+A scope consists of a pattern to match a focused application window title, window class, executable path, or executable
+base filename, and a list of associated macros that only apply if a window matching the pattern is currently focused.
+A scope looks like this:
 
 ```yaml
 window_class:
   is: "exact text"
 window_name:
   contains: "partial text"
+executable_path:
+  regex: "^regular expression$"
+executable_basename:
+  starts_with: "something"
   
 macros:
   - ...
@@ -67,7 +72,12 @@ macros:
 - `window_class`: matches against a window class of the focused window. The matching object is documented below, see
   string matching.
 - `window_name`: matches against a window name of the focused window. Matching works the same.
+- `executable_path`: Full absolute path to the executable file responsible for the focused window
+- `executable_basename`: Like `executable_path`, but only the filename without the directory it is in, for convenience.
 - `macros`: List of macros that apply to this scope, documented in Macros.
+
+`window_class`, `window_name`, `executable_path`, and `executable_basename` are all "string matchers", which are
+described below.
 
 ### String matching
 

--- a/mmpd-lib/src/config/versions/version1/macros.rs
+++ b/mmpd-lib/src/config/versions/version1/macros.rs
@@ -404,7 +404,9 @@ mod tests {
 
                 scope: Some(Scope {
                     window_class: None,
-                    window_name: Some(StringMatcher::Is("match".to_string()))
+                    window_name: Some(StringMatcher::Is("match".to_string())),
+                    executable_path: None,
+                    executable_basename: None,
                 })
             }
         );
@@ -493,7 +495,9 @@ mod tests {
 
                     scope: Some(Scope {
                         window_class: None,
-                        window_name: Some(StringMatcher::Is("match".to_string()))
+                        window_name: Some(StringMatcher::Is("match".to_string())),
+                        executable_path: None,
+                        executable_basename: None,
                     })
                 },
 
@@ -520,7 +524,9 @@ mod tests {
 
                     scope: Some(Scope {
                         window_class: None,
-                        window_name: Some(StringMatcher::Is("match".to_string()))
+                        window_name: Some(StringMatcher::Is("match".to_string())),
+                        executable_path: None,
+                        executable_basename: None,
                     })
                 },
             ]

--- a/mmpd-lib/src/focus.rs
+++ b/mmpd-lib/src/focus.rs
@@ -21,6 +21,8 @@ pub use mac_os::get_adapter;
 pub struct FocusedWindow {
     pub window_class: Vec<String>,
     pub window_name: String,
+    pub executable_path: Option<String>,
+    pub executable_basename: Option<String>,
 }
 
 /// Adapters implementing this trait can be asked to provided data on the currently focused window.

--- a/mmpd-lib/src/focus/mac_os.rs
+++ b/mmpd-lib/src/focus/mac_os.rs
@@ -1,5 +1,6 @@
 use crate::focus::{FocusAdapter, FocusedWindow};
 use std::process::Command;
+use std::path::Path;
 
 pub fn get_adapter() -> Option<Box<impl FocusAdapter>> {
     MacOs::new().map(|mac_os| Box::new(mac_os))
@@ -39,8 +40,18 @@ impl FocusAdapter for MacOs {
         let output_lines: Vec<&str> = output_raw.trim().split("\n").collect();
 
         // If number of lines doesn't match what expect we can't reliably retrieve correct info
-        if output_lines.len() != 3 {
+        if output_lines.len() != 4 {
             return None;
+        }
+
+        let executable_path = output_lines[3].to_string();
+        let exec_path = Path::new(executable_path.as_str());
+        let mut executable_basename: Option<String> = None;
+
+        if let Some(file_name) = exec_path.file_name() {
+            if let Some(file_name) = file_name.to_str() {
+                executable_basename = Some(file_name.to_string());
+            }
         }
 
         Some(FocusedWindow {
@@ -51,8 +62,8 @@ impl FocusAdapter for MacOs {
             ],
             window_name: output_lines[2].to_string(),
 
-            executable_path: None, // TODO
-            executable_basename: None,
+            executable_path: Some(executable_path),
+            executable_basename,
         })
     }
 }

--- a/mmpd-lib/src/focus/mac_os.rs
+++ b/mmpd-lib/src/focus/mac_os.rs
@@ -49,7 +49,10 @@ impl FocusAdapter for MacOs {
                 output_lines[0].to_string(),
                 output_lines[1].to_string()
             ],
-            window_name: output_lines[2].to_string()
+            window_name: output_lines[2].to_string(),
+
+            executable_path: None, // TODO
+            executable_basename: None,
         })
     }
 }

--- a/mmpd-lib/src/focus/mac_os/get_window_info.scpt
+++ b/mmpd-lib/src/focus/mac_os/get_window_info.scpt
@@ -2,7 +2,7 @@
 -- With thanks to this StackOverflow answer by Albert
 -- https://stackoverflow.com/a/5293758/1019228
 
-global frontApp, frontAppName, frontAppClass, windowTitle
+global frontApp, frontAppName, frontAppClass, windowTitle, executablePath
 set windowTitle to ""
 
 tell application "System Events"
@@ -12,6 +12,8 @@ tell application "System Events"
     -- be the values we populate window_class with
     set frontAppName to name of frontApp
     set frontAppClass to displayed name of frontApp
+    -- Get the absolute path of the application owning this window
+    set executablePath to POSIX path of (application file of frontApp)
 
     -- Get the window title
     tell process frontAppName
@@ -19,8 +21,7 @@ tell application "System Events"
             set windowTitle to value of attribute "AXTitle"
         end tell
     end tell
-
 end tell
 
--- Print app class, app name, and window title to STDOUT on their own lines
-copy frontAppClass & "\n" & frontAppName & "\n" & windowTitle to stdout
+-- Print app class, app name, window title, executable path to STDOUT on their own lines
+copy frontAppClass & "\n" & frontAppName & "\n" & windowTitle & "\n" & executablePath to stdout

--- a/mmpd-lib/src/focus/windows.rs
+++ b/mmpd-lib/src/focus/windows.rs
@@ -33,7 +33,9 @@ impl FocusAdapter for Windows {
         Some(
             FocusedWindow {
                 window_class: get_window_class(foreground_handle)?,
-                window_name: get_window_name(foreground_handle)?
+                window_name: get_window_name(foreground_handle)?,
+                executable_path: None, // TODO
+                executable_basename: None
             }
         )
     }

--- a/mmpd-lib/src/focus/windows.rs
+++ b/mmpd-lib/src/focus/windows.rs
@@ -4,15 +4,22 @@ use windows_bindings::Windows::Win32::WindowsAndMessaging::{
     GetForegroundWindow,
     GetWindowTextW,
     GetClassNameW,
+    GetWindowThreadProcessId,
     HWND,
 };
 
 use windows_bindings::Windows::Win32::SystemServices::{
+    BOOL,
     PWSTR,
+    PROCESS_ACCESS_RIGHTS,
+    OpenProcess,
+    QueryFullProcessImageNameW,
+    QueryFullProcessImageName_dwFlags,
 };
 
 use std::os::windows::ffi::OsStringExt;
 use std::ffi::OsString;
+use std::path::Path;
 
 pub fn get_adapter() -> Option<Box<impl FocusAdapter>> {
     Windows::new().map(|windows| Box::new(windows))
@@ -29,13 +36,31 @@ impl Windows {
 impl FocusAdapter for Windows {
     fn get_focused_window(&self) -> Option<FocusedWindow> {
         let foreground_handle = get_focused_window_handle()?;
+        let window_class = get_window_class(foreground_handle)?;
+        let window_name = get_window_name(foreground_handle)?;
+
+        let executable_path = get_process_executable(
+            get_window_process_id(foreground_handle)
+        );
+
+        let mut executable_basename: Option<String> = None;
+
+        if let Some(exec_path) = executable_path.clone() {
+            let exec_path = Path::new(exec_path.as_str());
+
+            if let Some(file_name) = exec_path.file_name() {
+                if let Some(file_name) = file_name.to_str() {
+                    executable_basename = Some(file_name.to_string());
+                }
+            }
+        }
 
         Some(
             FocusedWindow {
-                window_class: get_window_class(foreground_handle)?,
-                window_name: get_window_name(foreground_handle)?,
-                executable_path: None, // TODO
-                executable_basename: None
+                window_class,
+                window_name,
+                executable_path,
+                executable_basename
             }
         )
     }
@@ -79,4 +104,47 @@ fn get_window_class(window_handle: HWND) -> Option<Vec<String>> {
         let os_string: OsString = OsStringExt::from_wide(&chars[0..len]);
         os_string.to_str().map(|s| vec![s.to_string()])
     }
+}
+
+fn get_window_process_id(window_handle: HWND) -> u32 {
+    let mut pid: u32 = 0;
+    let _ = unsafe { GetWindowThreadProcessId(window_handle, &mut pid) };
+    pid
+}
+
+fn get_process_executable(pid: u32) -> Option<String> {
+    let process_handle = unsafe {
+        OpenProcess(
+            PROCESS_ACCESS_RIGHTS::PROCESS_QUERY_LIMITED_INFORMATION,
+            false, // bInheritHandle: Not having sub-processes inherit this handle
+            pid    // dwProcessId: process we're getting info for
+        )
+    };
+
+    if process_handle.is_null() {
+        return None;
+    }
+
+    // Storage for the path
+    let mut chars: [u16; MAX_STR_LEN] = [0; MAX_STR_LEN];
+    let pwstr = PWSTR(chars.as_mut_ptr());
+    let mut len: u32 = MAX_STR_LEN as u32;
+
+    let result = unsafe {
+        QueryFullProcessImageNameW(
+            process_handle,
+            QueryFullProcessImageName_dwFlags(0),
+            pwstr,
+            &mut len,
+        )
+    };
+
+    // If we failed to get the info for any reason, return None.
+    // If this is hit at some point, use GetLastError to figure out why.
+    if let BOOL(0) = result {
+        return None;
+    }
+
+    let os_string: OsString = OsStringExt::from_wide(&chars[0..len as usize]);
+    os_string.to_str().map(|s| s.to_string())
 }

--- a/mmpd-lib/src/focus/x11/x11_sys.rs
+++ b/mmpd-lib/src/focus/x11/x11_sys.rs
@@ -1,6 +1,10 @@
 use x11::xlib;
-use std::ffi::c_void;
+use std::ffi::{c_void, CString, NulError};
 use std::os::raw::{c_long, c_ulong, c_int, c_uchar};
+use std::convert::TryInto;
+use std::mem::size_of;
+use std::fs::read_link;
+use std::path::{Path, PathBuf};
 
 use crate::focus::FocusedWindow;
 
@@ -25,12 +29,26 @@ impl X11Sys {
     pub fn get_window_info(&self, window_id: xlib::Window) -> Option<FocusedWindow> {
         let window_class = self.get_window_prop_strings(window_id, xlib::XA_WM_CLASS)?;
         let window_name = self.get_window_prop_strings(window_id, xlib::XA_WM_NAME)?;
+        let mut window_executable_path: Option<String> = None;
+        let mut window_executable_basename: Option<String> = None;
+
+        if let Some(exec_path) = self.get_window_executable_path(window_id) {
+            if let Some(path) = exec_path.to_str() {
+                window_executable_path = Some(path.to_string());
+            }
+
+            if let Some(file_name) = exec_path.file_name() {
+                if let Some(file_name) = file_name.to_str() {
+                    window_executable_basename = Some(file_name.to_string());
+                }
+            }
+        }
 
         Some(FocusedWindow {
             window_class,
             window_name: window_name.first()?.to_string(),
-            executable_path: None, // TODO
-            executable_basename: None, // TODO
+            executable_path: window_executable_path,
+            executable_basename: window_executable_basename
         })
     }
 
@@ -79,7 +97,7 @@ impl X11Sys {
         let mut bytes_after: c_ulong = 0;
 
         // Where XGetWindowProperty will store a pointer to an array it has allocated, containing
-        // the data of the requested property. This must later be cast to the approriate type to
+        // the data of the requested property. This must later be cast to the appropriate type to
         // access the data.
         let mut prop_ptr_ptr: *mut c_uchar = std::ptr::null_mut();
 
@@ -130,9 +148,114 @@ impl X11Sys {
 
         Some(strings)
     }
+
+    fn get_window_prop_int(
+        &self,
+        window_id: xlib::Window,
+        property_name: xlib::Atom
+    ) -> Option<u32> {
+
+        // In the data for the property we're reading, return data starting at this offset
+        // The offset is in terms of "items", however large they may be. In this function
+        // we're only concerned with bytes.
+        const READ_OFFSET: c_long = 0;
+
+        // Maximum number of items to (in our case, bytes) to read from this property
+        const READ_LENGTH: c_long = 4;
+
+        // Requested type, We're setting it to "any" and then checking what the actual found
+        // format was later.
+        let req_type: xlib::Atom = xlib::AnyPropertyType as xlib::Atom;
+
+        // Where XGetWindowProperty will store the type of the property value found.
+        // We don't do anything with this value
+        let mut actual_type: xlib::Atom = 0;
+
+        // Where XGetWindowProperty will store the "item" size. We expect this to be 8 (byte).
+        // If it does not get set to 8, this function will return None.
+        let mut actual_format: c_int = 0;
+
+        // Where XGetWindowProperty will store the number of items available in the array pointed
+        // to by prop_ptr_ptr.
+        let mut nitems: c_ulong = 0;
+
+        // Where XGetWindowProperty will store the number of bytes left beyond our read length
+        // (always in bytes). We don't use this value and assume that contents returned will always
+        // fit within READ_LENGTH.
+        let mut bytes_after: c_ulong = 0;
+
+        // Where XGetWindowProperty will store a pointer to an array it has allocated, containing
+        // the data of the requested property. This must later be cast to the appropriate type to
+        // access the data.
+        let mut prop_ptr_ptr: *mut c_uchar = std::ptr::null_mut();
+
+        let result = unsafe {
+            xlib::XGetWindowProperty(
+                self.display,
+                window_id,
+                property_name,
+                READ_OFFSET,
+                READ_LENGTH,
+                false as i32, // Do not delete the property from the window
+
+                req_type,
+                &mut actual_type,
+                &mut actual_format,
+                &mut nitems,
+                &mut bytes_after,
+                &mut prop_ptr_ptr
+            )
+        };
+
+        // If the call was unsuccessful, we won't try anything else and return no data.
+        if result != xlib::Success as c_int { return None; }
+
+        // Expect 32 bit numbers
+        if actual_format != 32 { return None; }
+
+        // Create a slice of bytes from the result data, turn it into a 4-byte array
+        let raw_bytes: [u8; size_of::<u32>()] = unsafe {
+            std::slice::from_raw_parts(prop_ptr_ptr, size_of::<u32>())
+        }[0..size_of::<u32>()].try_into().ok()?;
+
+        // Build a u32 from the raw bytes
+        let num = u32::from_ne_bytes(raw_bytes);
+
+        unsafe {
+            // As documented here:
+            // https://tronche.com/gui/x/xlib/window-information/XGetWindowProperty.html
+            // we must free the memory XGetWindowProperty allocated
+            // using XFree.
+            xlib::XFree(prop_ptr_ptr as *mut c_void);
+        }
+
+        Some(num)
+    }
+
+    /// Builds an atom for a given string name
+    fn get_atom(&self, atom_name: &str) -> Result<xlib::Atom, NulError> {
+        let atom_name_c = CString::new(atom_name)?;
+
+        Ok(unsafe {
+            xlib::XInternAtom(
+                self.display,
+                atom_name_c.as_ptr(),
+                false as i32
+            )
+        })
+    }
+
+    /// Gets the executable path for a given window
+    fn get_window_executable_path(&self, window_id: xlib::Window) -> Option<PathBuf> {
+        let pid_prop_atom = self.get_atom("_NET_WM_PID").ok()?;
+        let pid = self.get_window_prop_int(window_id, pid_prop_atom)?;
+
+        let path_str = format!("/proc/{}/exe", pid);
+        read_link(Path::new(path_str.as_str())).ok()
+    }
 }
 
-///Decodes a nul-separated byte array into a Vec of strings
+/// Decodes a nul-separated byte array into a Vec of strings
 fn decode_strings(bytes: &[u8]) -> Vec<String> {
     let mut strings: Vec<String> = vec![];
 

--- a/mmpd-lib/src/focus/x11/x11_sys.rs
+++ b/mmpd-lib/src/focus/x11/x11_sys.rs
@@ -28,7 +28,9 @@ impl X11Sys {
 
         Some(FocusedWindow {
             window_class,
-            window_name: window_name.first()?.to_string()
+            window_name: window_name.first()?.to_string(),
+            executable_path: None, // TODO
+            executable_basename: None, // TODO
         })
     }
 

--- a/mmpd-lib/src/keyboard_control/xdo.rs
+++ b/mmpd-lib/src/keyboard_control/xdo.rs
@@ -2,7 +2,6 @@ extern crate libxdo;
 
 use crate::keyboard_control::{KeyboardControlAdapter, KeyboardResult, KeyboardControlError};
 use libxdo::XDo;
-use std::error::Error;
 
 pub fn get_adapter() -> Option<Box<impl KeyboardControlAdapter>> {
     Xdo::new().map(|xdo| Box::new(xdo))

--- a/mmpd-lib/src/macros.rs
+++ b/mmpd-lib/src/macros.rs
@@ -12,14 +12,36 @@ pub mod preconditions;
 pub struct Scope {
     pub window_class: Option<StringMatcher>,
     pub window_name: Option<StringMatcher>,
+    pub executable_path: Option<StringMatcher>,
+    pub executable_basename: Option<StringMatcher>
 }
 
 impl Scope {
     pub fn new<'a>(
         window_class: Option<StringMatcher>,
-        window_name: Option<StringMatcher>
+        window_name: Option<StringMatcher>,
+        executable_path: Option<StringMatcher>,
+        executable_basename: Option<StringMatcher>
     ) -> Scope {
-        Scope { window_class, window_name }
+        Scope {
+            window_class,
+            window_name,
+            executable_path,
+            executable_basename
+        }
+    }
+
+    /// Turns the instance into an option, as a convenience for checking whether _any_ of its
+    /// matchers are `Some`. Returns `None` if all contained matchers are `None`.
+    pub fn into_option(self) -> Option<Scope> {
+        if self.window_class.is_some() ||
+            self.window_name.is_some() ||
+            self.executable_path.is_some() ||
+            self.executable_basename.is_some() {
+            Some(self)
+        } else {
+            None
+        }
     }
 }
 

--- a/mmpd-lib/src/state.rs
+++ b/mmpd-lib/src/state.rs
@@ -56,33 +56,52 @@ impl State for StateImpl {
 
         let scope = scope.clone().unwrap();
 
-        if scope.window_name.is_none() && scope.window_class.is_none() {
-            return true
-        }
-
         let window = self.focus_adapter.get_focused_window();
 
-        return if let Some(window) = window {
-            if let Some(window_name) = &scope.window_name {
-                if !window_name.matches(&window.window_name.as_ref()) {
-                    return false
-                }
-            }
+        // If there is no focused window, but we have scope qualifiers, we cannot match
+        if window.is_none() {
+            return false
+        }
 
-            if let Some(window_class) = &scope.window_class {
-                for wcls in window.window_class {
-                    if window_class.matches(&wcls.as_ref()) {
-                        return true
-                    }
-                }
+        let window = window.unwrap();
 
+        if let Some(window_name) = &scope.window_name {
+            if !window_name.matches(&window.window_name.as_ref()) {
                 return false
             }
-
-            true
-        } else {
-            true
         }
+
+        if let Some(window_class) = &scope.window_class {
+            if !window.window_class.iter().any(|wc| window_class.matches(&wc.as_ref())) {
+                return false;
+            }
+        }
+
+        if let Some(executable_path) = &scope.executable_path {
+            if window.executable_path.is_none() {
+                return false;
+            }
+
+            let w_exec_path = window.executable_path.unwrap();
+
+            if !executable_path.matches(&w_exec_path.as_ref()) {
+                return false;
+            }
+        }
+
+        if let Some(executable_basename) = &scope.executable_basename {
+            if window.executable_basename.is_none() {
+                return false;
+            }
+
+            let w_exec_basename = window.executable_basename.unwrap();
+
+            if !executable_basename.matches(&w_exec_basename.as_ref()) {
+                return false;
+            }
+        }
+
+        true
     }
 
     fn matches_precondition(&self, precondition: &Precondition) -> bool {
@@ -99,3 +118,5 @@ impl State for StateImpl {
         }
     }
 }
+
+// TODO: tests for StateImpl

--- a/testcfg.yml
+++ b/testcfg.yml
@@ -4,17 +4,17 @@ midi_device:
   contains: "KeyStep"
 
 scopes:
-  - window_name:
-      ends_with: "Inkscape"
+  - executable_basename:
+      is: "inkscape"
 
     macros:
-      - name: "Inkscape align objects horizontally"
+      - name: "Inkscape align objects vertically"
         matching_events:
           - type: midi
             data:
               message_type: note_on
               channel: 0
-              key: 48
+              key: A2
         actions:
           - type: key_sequence
             data: "ctrl+shift+a Tab Tab Tab Tab Tab Tab Return"

--- a/windows_bindings/build.rs
+++ b/windows_bindings/build.rs
@@ -10,13 +10,16 @@ fn main() {
         },
 
         Windows::Win32::SystemServices::{
-            PWSTR
+            PWSTR,
+            OpenProcess,
+            QueryFullProcessImageNameW,
         },
 
         Windows::Win32::WindowsAndMessaging::{
             GetForegroundWindow,
             GetWindowTextW,
             GetClassNameW,
+            GetWindowThreadProcessId,
             VK_ACCEPT,
             VK_ADD,
             VK_APPS,


### PR DESCRIPTION
This adds `executable_path` and `executable_basename` to the `FocusedWindow` struct, and makes them available in scope configuration, so you can filter not only on window title, window class, but also the underlying executable file, for more precise application targeting.

Includes implementations for retrieving this information using X11 (Linux), AppleScript (Mac OS), and Windows.